### PR TITLE
Update flake.lock and enhance Home Manager configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744618730,
-        "narHash": "sha256-n3gN7aHwVRnnBZI64EDoKyJnWidNYJ0xezhqQtdjH2Q=",
+        "lastModified": 1744833442,
+        "narHash": "sha256-BBMWW2m64Grcc5FlXz74+vdkUyCJOfUGnl+VcS/4x44=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "85dd758c703ffbf9d97f34adcef3a898b54b4014",
+        "rev": "c6b75d69b6994ba68ec281bd36faebcc56097800",
         "type": "github"
       },
       "original": {

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -79,6 +79,11 @@
 
   # List of packages managed by Home Manager
   home.packages = with pkgs; [
+    # Add direnv for automatic environment switching
+    direnv
+    # Add pipx package itself
+    pipx
+
     # Cloud SDKs (Managed via Homebrew now)
     
     # Core packages required for basic functionality (Example: oh-my-zsh)
@@ -95,6 +100,12 @@
     };
     # FZF settings moved to zsh.nix
     home-manager.enable = true;
+
+    # Direnv Configuration for Flake Integration
+    direnv = {
+      enable = true;
+      nix-direnv.enable = true; # Important for 'use flake'
+    };
   };
 
   # Enable font configuration

--- a/home-manager/modules/zsh.nix
+++ b/home-manager/modules/zsh.nix
@@ -8,11 +8,6 @@
 # - Manages history
 #
 # Manages:
-# - Shell environment setup
-# - PATH management
-#   - pipx binaries ($HOME/.local/bin)
-#   - poetry ($HOME/Library/Application Support/pypoetry/venv/bin)
-#   - pyenv initialization
 #
 # Tool initializations:
 # - SDKMAN for Java version management


### PR DESCRIPTION
- Refresh flake.lock with updated dependencies for Home Manager
- Add direnv and pipx to Home Manager packages for improved environment management
- Enable direnv configuration for flake integration
- Remove outdated comments from zsh.nix regarding shell environment setup