### PR TITLE
Add Google Cloud SDK to Homebrew configuration

### DIFF
--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -174,6 +174,7 @@
       # Development Tools (Other)
       "cursor"
       "docker"
+      "google-cloud-sdk"    # Google Cloud SDK
       "jetbrains-toolbox"   # JetBrains IDE manager
       "postman"             # API testing tool
       "visual-studio-code"  # Code editor


### PR DESCRIPTION
- Include "google-cloud-sdk" in the list of development tools for enhanced cloud development support.