### PR TITLE
Document local monitoring reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ result-*
 # Logs and databases
 *.log
 *.sqlite
+# Generated monitoring reports
+.health-reports/
+.performance-reports/
 # Environment files
 .env
 .envrc

--- a/docs/monitoring/system-health.md
+++ b/docs/monitoring/system-health.md
@@ -260,6 +260,8 @@ Generated reports are stored in `.health-reports/`:
 - **health_report_TIMESTAMP.txt** - Comprehensive health reports
 - **maintenance_TIMESTAMP.log** - Maintenance task logs
 
+These reports are generated locally and ignored by git.
+
 ### Performance Reports
 
 Performance analysis reports in `.performance-reports/`:
@@ -267,6 +269,8 @@ Performance analysis reports in `.performance-reports/`:
 - **system_analysis_TIMESTAMP.txt** - System configuration analysis
 - **rebuild_profile_TIMESTAMP.txt** - Build performance profiles
 - **cache_analysis_TIMESTAMP.txt** - Binary cache performance
+
+These reports are generated locally and ignored by git.
 
 ### Report Analysis
 


### PR DESCRIPTION
## Summary
- ignore generated monitoring report directories
- document that health and performance reports are local-only outputs

## Checks
- ./scripts/testing/check-docs-stale-patterns.sh
- git diff --check