### PR TITLE
Configure statusline and tooling updates

### DIFF
--- a/darwin/homebrew-packages/brews/development.nix
+++ b/darwin/homebrew-packages/brews/development.nix
@@ -3,6 +3,7 @@
 # Prefer Home Manager for user-level CLI tools. Keep tools here only when their
 # Homebrew installation is the deliberate global source of truth.
 [
+  "kubevela"
   "neovim"
   "yamlresume"
 ]

--- a/docs/monitoring/system-health.md
+++ b/docs/monitoring/system-health.md
@@ -215,6 +215,13 @@ health-maintain
 ./scripts/monitoring/system-health-monitor.sh --maintain
 ```
 
+Maintenance prompts for confirmation in interactive shells. For non-interactive
+runs, set `HEALTH_MAINTAIN_CONFIRM=1` explicitly:
+
+```bash
+HEALTH_MAINTAIN_CONFIRM=1 ./scripts/monitoring/system-health-monitor.sh --maintain
+```
+
 ## Configuration
 
 ### Threshold Configuration

--- a/flake.lock
+++ b/flake.lock
@@ -182,11 +182,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776373306,
-        "narHash": "sha256-iAJIzHngGZeLIkjzuuWI6VBsYJ1n89a/Esq0m8R1vjs=",
+        "lastModified": 1776721614,
+        "narHash": "sha256-zGuW7C4tsScib2560yE5VV6lY/MdRs30aU9cbg3RP+U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d401492e2acd4fea42f7705a3c266cea739c9c36",
+        "rev": "c555a4a34a260493be5adb795c54e013c58f2d34",
         "type": "github"
       },
       "original": {
@@ -215,11 +215,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776255774,
-        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {

--- a/home-manager/aliases/git.nix
+++ b/home-manager/aliases/git.nix
@@ -159,8 +159,8 @@
   # ==========================================================================
   # Workflow Shortcuts
   # ==========================================================================
-  gsync = "git fetch origin && git checkout main && git pull origin main"; # Sync with main branch
-  gup = "git fetch && git rebase origin/main"; # Update current branch from main
+  gsync = "git fetch origin && if branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD); then branch=\${branch#origin/}; elif git show-ref --verify --quiet refs/remotes/origin/main; then branch=main; elif git show-ref --verify --quiet refs/remotes/origin/master; then branch=master; else echo 'No origin/main or origin/master found.' >&2; false; fi && git checkout \"$branch\" && git pull --ff-only origin \"$branch\""; # Sync with main/master branch
+  gup = "git fetch origin && if branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD); then branch=\${branch#origin/}; elif git show-ref --verify --quiet refs/remotes/origin/main; then branch=main; elif git show-ref --verify --quiet refs/remotes/origin/master; then branch=master; else echo 'No origin/main or origin/master found.' >&2; false; fi && git rebase \"origin/$branch\""; # Update current branch from main/master
   gnuke = "git reset --hard && git clean -fd"; # Nuclear option - reset everything (DESTRUCTIVE!)
 
   # Quick workflow combinations

--- a/home-manager/config/claude.nix
+++ b/home-manager/config/claude.nix
@@ -2,8 +2,10 @@
   awsProfile = "default-sso";
 
   useBedrock = "1";
-  maxOutputTokens = "8192";
-  maxThinkingTokens = "4096";
+  maxOutputTokens = "16384";
+  maxThinkingTokens = "8192";
+  model = "opus";
+  effortLevel = "medium";
 
   # EU geo inference endpoints keep the default model path GDPR-friendly.
   models = {

--- a/home-manager/config/ssh.nix
+++ b/home-manager/config/ssh.nix
@@ -20,6 +20,7 @@
     ha = "192.168.10.24";
     linkwarden = "192.168.10.29";
     windmill = "192.168.10.30";
+    paperlessng = "192.168.10.20";
 
     metric-exporter = "192.168.10.32";
     prometheus = "192.168.10.17";

--- a/home-manager/modules/claude-code.nix
+++ b/home-manager/modules/claude-code.nix
@@ -8,8 +8,9 @@
 # - Sets environment variables for Bedrock API access
 #
 # How it works:
-# - Creates ~/.claude/settings.default.json with Bedrock configuration
-# - Bootstraps ~/.claude/settings.json only if missing so plugins can mutate it
+# - Creates ~/.claude/settings.default.json with Bedrock/statusline configuration
+# - Creates ~/.claude/statusline.default.sh with the default statusline script
+# - Bootstraps mutable Claude files only if missing so Claude can mutate them
 # - Uses EU region endpoints for GDPR compliance
 # - Auto-refreshes AWS SSO credentials when they expire
 #
@@ -21,11 +22,16 @@
 # Usage:
 # - Run 'claude' in terminal to start Claude Code
 # - Credentials auto-refresh via awsAuthRefresh command
-{ lib, ... }:
+{
+  config,
+  lib,
+  ...
+}:
 let
   claude = import ../config/claude.nix;
   aws = import ../config/aws.nix;
   inherit (aws) region;
+  statuslinePath = "${config.home.homeDirectory}/.claude/statusline.sh";
   settings = builtins.toJSON {
     # AWS SSO auto-refresh command
     # Runs automatically when Bedrock returns credential errors
@@ -54,6 +60,14 @@ let
       # Opus: Most capable (for complex reasoning)
       ANTHROPIC_DEFAULT_OPUS_MODEL = claude.models.opus;
     };
+
+    model = claude.model;
+    effortLevel = claude.effortLevel;
+    statusLine = {
+      type = "command";
+      command = "bash \"${statuslinePath}\"";
+      refreshInterval = 30;
+    };
   };
 in
 {
@@ -62,6 +76,10 @@ in
   # Location: ~/.claude/settings.default.json
   # Docs: https://docs.anthropic.com/claude-code/configuration
   home.file.".claude/settings.default.json".text = settings;
+  home.file.".claude/statusline.default.sh" = {
+    source = ./claude-code/statusline.sh;
+    executable = true;
+  };
 
   home.activation.ensureClaudeMutableSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     mkdir -p "$HOME/.claude"
@@ -72,6 +90,10 @@ in
 
     if [ ! -e "$HOME/.claude/settings.json" ]; then
       install -m 600 "$HOME/.claude/settings.default.json" "$HOME/.claude/settings.json"
+    fi
+
+    if [ ! -e "$HOME/.claude/statusline.sh" ]; then
+      install -m 755 "$HOME/.claude/statusline.default.sh" "$HOME/.claude/statusline.sh"
     fi
   '';
 }

--- a/home-manager/modules/claude-code/statusline.sh
+++ b/home-manager/modules/claude-code/statusline.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Claude Code statusline template.
+#
+# Claude reads JSON status data on stdin and renders a compact statusline with
+# branch, context usage, cost, cache hit rate, rate limit, and caveman mode.
+set -euo pipefail
+
+input=$(cat)
+
+PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
+COST=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
+COST_FMT=$(printf '$%.2f' "$COST")
+RL5=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // 0' | cut -d. -f1)
+CACHE_READ=$(echo "$input" | jq -r '.context_window.current_usage.cache_read_input_tokens // 0')
+INPUT=$(echo "$input" | jq -r '.context_window.current_usage.input_tokens // 0')
+BRANCH=$(git branch --show-current 2>/dev/null || true)
+
+# Mini context bar.
+FILLED=$((PCT * 6 / 100))
+EMPTY=$((6 - FILLED))
+BAR=""
+[ "$FILLED" -gt 0 ] && printf -v F "%${FILLED}s" && BAR="${F// /█}"
+[ "$EMPTY" -gt 0 ] && printf -v E "%${EMPTY}s" && BAR="${BAR}${E// /░}"
+
+# Context color.
+if [ "$PCT" -ge 80 ]; then
+  C=$'\033[31m'
+elif [ "$PCT" -ge 50 ]; then
+  C=$'\033[33m'
+else
+  C=$'\033[32m'
+fi
+R=$'\033[0m'
+DIM=$'\033[2m'
+CYAN=$'\033[36m'
+
+# Rate limit: only show if >40%.
+RL_PART=""
+[ "$RL5" -ge 40 ] && RL_PART="  ${C}rl:${RL5}%${R}"
+
+# Cache hit: only show if >0 cache reads.
+CACHE_PART=""
+if [ "$INPUT" -gt 0 ] && [ "$CACHE_READ" -gt 0 ]; then
+  CACHE_PCT=$((CACHE_READ * 100 / (INPUT + CACHE_READ)))
+  CACHE_PART="  ${DIM}cache:${CACHE_PCT}%${R}"
+fi
+
+# Branch: only show if in git repo.
+BR_PART=""
+[ -n "$BRANCH" ] && BR_PART="  ${CYAN}${BRANCH}${R}"
+
+echo -e "${BR_PART}  ${C}${BAR} ${PCT}%${R}  ${DIM}${COST_FMT}${R}${CACHE_PART}${RL_PART}" | sed 's/^  //'

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -80,7 +80,8 @@ scripts/
 - CPU, memory, disk, and network monitoring
 - Nix store health checks
 - Automated maintenance tasks
-- **Usage**: `./scripts/monitoring/system-health-monitor.sh [--check|--maintain|--report]`
+- Alert checks for critical issues
+- **Usage**: `./scripts/monitoring/system-health-monitor.sh [--check|--maintain|--report|--alert]`
 
 ### `monitoring/analyze-build-performance.sh`
 


### PR DESCRIPTION
## Summary
- add Claude Code statusline defaults managed by Home Manager
- update Claude Code default model/token settings
- add KubeVela Homebrew formula
- make git sync aliases work with main or master
- add homelab SSH host and refresh flake lock
- include monitoring docs drift cleanup

## Checks
- bash -n home-manager/modules/claude-code/statusline.sh
- shellcheck home-manager/modules/claude-code/statusline.sh
- ./scripts/testing/check-package-ownership.sh
- ./scripts/testing/check-docs-stale-patterns.sh
- git diff --check
- nix eval .#darwinConfigurations.satya-wmbp.system.drvPath --raw