### PR TITLE
Enable terminal hyperlinks in statusline

### DIFF
--- a/home-manager/modules/claude-code/statusline.sh
+++ b/home-manager/modules/claude-code/statusline.sh
@@ -140,17 +140,47 @@ MODEL_PART=""
 
 CWD_PART=""
 GIT_PART=""
+PR_PART=""
 if [ -n "$CWD" ]; then
   CWD_SHORT="${CWD/#$HOME/\~}"
   CWD_PART="${CYAN}${CWD_SHORT}${R}"
   BRANCH=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
   [ -n "$BRANCH" ] && GIT_PART="${DIM}(${BRANCH})${R}"
+
+  # Active PR for current branch, cached briefly to avoid statusline latency.
+  if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "develop" ] && [ "$BRANCH" != "HEAD" ] && command -v gh >/dev/null 2>&1; then
+    SESSION_ID=$(echo "$input" | jq -r '.session_id // empty')
+    CACHE_BRANCH=$(printf '%s' "$BRANCH" | tr '/:' '--')
+    CACHE_FILE="/tmp/claude-pr-cache-${SESSION_ID:-default}-${CACHE_BRANCH}"
+    NOW=$(date +%s)
+    CACHE_AGE=999999
+    if [ -f "$CACHE_FILE" ]; then
+      CACHE_MTIME=$(stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0)
+      CACHE_AGE=$((NOW - CACHE_MTIME))
+    fi
+
+    if [ "$CACHE_AGE" -gt 60 ]; then
+      PR_NUM=$(gh pr list --state open --head "$BRANCH" --json number -q '.[0].number' 2>/dev/null || true)
+      printf '%s' "${PR_NUM:-}" > "$CACHE_FILE"
+    else
+      PR_NUM=$(cat "$CACHE_FILE" 2>/dev/null || true)
+    fi
+
+    if [ -n "${PR_NUM:-}" ]; then
+      REPO_URL=$(git -C "$CWD" remote get-url origin 2>/dev/null | sed 's|git@github.com:|https://github.com/|;s|\.git$||' || true)
+      if [ -n "$REPO_URL" ]; then
+        PR_URL="${REPO_URL}/pull/${PR_NUM}"
+        PR_PART=" ${CYAN}\033]8;;${PR_URL}\033\\PR #${PR_NUM}\033]8;;\033\\${R}"
+      fi
+    fi
+  fi
 fi
 
 ROW1=""
 [ -n "$MODEL_PART" ] && ROW1="${MODEL_PART}"
 [ -n "$CWD_PART" ] && ROW1="${ROW1} | ${CWD_PART}"
 [ -n "$GIT_PART" ] && ROW1="${ROW1} ${GIT_PART}"
+[ -n "$PR_PART" ] && ROW1="${ROW1}${PR_PART}"
 [ -n "$PLUGIN_PART" ] && ROW1="${ROW1} | ${PLUGIN_PART}"
 
 # Row 2: usage, tokens, cost, timing, limits.

--- a/home-manager/modules/tmux.nix
+++ b/home-manager/modules/tmux.nix
@@ -71,6 +71,7 @@
       set -g status-position top
       set -g default-terminal "screen-256color"
       set -ag terminal-overrides ",xterm-256color:RGB"
+      set -g allow-passthrough all
       set -g update-environment "DISPLAY KRB5CCNAME SSH_ASKPASS SSH_AUTH_SOCK SSH_AGENT_PID SSH_CONNECTION WINDOWID XAUTHORITY DOCKER_CONFIG"
 
       # Pane Management


### PR DESCRIPTION
## Summary
- add OSC 8 PR hyperlinks to the Claude Code statusline when the current branch has an open PR
- cache PR lookups briefly to avoid statusline latency
- set tmux allow-passthrough to all so OSC 8 links work inside tmux

## Checks
- bash -n home-manager/modules/claude-code/statusline.sh
- shellcheck home-manager/modules/claude-code/statusline.sh
- git diff --check
- nix eval .#darwinConfigurations.satya-wmbp.system.drvPath --raw