### PR TITLE
[codex] Add app shortcuts and statusline refinements

### DIFF
--- a/docs/getting-started/quick-reference.md
+++ b/docs/getting-started/quick-reference.md
@@ -303,8 +303,11 @@ cd ~/Documents/dotfile && git stash && rebuild
 |----------|--------|
 | `Cmd+Shift+Enter` | Open Alacritty |
 | `Cmd+Shift+I` | Open IntelliJ IDEA |
-| `Cmd+Shift+P` | Open PyCharm |
+| `Cmd+Option+P` | Open PyCharm |
 | `Cmd+Shift+C` | Open Cursor |
+| `Cmd+Shift+X` | Open Codex |
+| `Cmd+Shift+D` | Open DataGrip |
+| `Cmd+Shift+A` | Open Calendar |
 | `Cmd+Shift+G` | Open Google Chrome |
 | `Cmd+Shift+B` | Open Brave Browser |
 

--- a/home-manager/aliases/README.md
+++ b/home-manager/aliases/README.md
@@ -28,6 +28,7 @@ aliases/
 | `gl` | Git pull | `gl` |
 | `d` | Docker | `d ps` |
 | `k` | Kubectl | `k get pods` |
+| `cc` | Claude Code | `cc` |
 | `rebuild` | Rebuild system (supports profile flags) | `rebuild --work` |
 | `cleanup` | Confirm, then clean system | `cleanup` |
 
@@ -51,6 +52,7 @@ aliases/
 
 ### 2. Development Tools (dev-tools.nix)
 - Modern CLI: `eza`, `fd`, `duf`, `btm`
+- Claude Code: `cc`, `ccc`, `ccr`
 - Tmux: `tn`, `ta`, `tk`, `t`
 - FZF: `fe`, `fcd`, `fif`, `fkill`
 - Docker: `d`, `dc`, `dsp`, `drm`, `dlog`

--- a/home-manager/aliases/dev-tools.nix
+++ b/home-manager/aliases/dev-tools.nix
@@ -65,6 +65,13 @@ in
   bmn = "btm --network_legend"; # Show network legend
 
   # ==========================================================================
+  # Claude Code
+  # ==========================================================================
+  cc = "claude"; # Claude Code shorthand
+  ccc = "claude --continue"; # Continue the latest Claude Code conversation
+  ccr = "claude --resume"; # Resume a Claude Code conversation
+
+  # ==========================================================================
   # Tmux Session Management
   # ==========================================================================
   tn = "tmux new -s"; # Create new named session - usage: tn mysession

--- a/home-manager/config/claude.nix
+++ b/home-manager/config/claude.nix
@@ -6,7 +6,7 @@
   # ~/.claude/settings.json without changing these template values.
   maxOutputTokens = "16384";
   maxThinkingTokens = "8192";
-  model = "sonnet";
+  model = "eu.anthropic.claude-sonnet-4-6";
   effortLevel = "low";
 
   # EU geo inference endpoints keep the default model path GDPR-friendly.

--- a/home-manager/modules/claude-code/statusline.sh
+++ b/home-manager/modules/claude-code/statusline.sh
@@ -20,6 +20,9 @@ CW_TOK=$(echo "$input" | jq -r '.context_window.current_usage.cache_creation_inp
 COST_RAW=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
 TOTAL_DURATION_MS=$(echo "$input" | jq -r '.cost.total_duration_ms // 0')
 API_TIME=$(echo "$input" | jq -r '.cost.total_api_duration_ms // 0')
+LINES_ADD=$(echo "$input" | jq -r '.cost.total_lines_added // 0')
+LINES_DEL=$(echo "$input" | jq -r '.cost.total_lines_removed // 0')
+EXCEEDS_200K=$(echo "$input" | jq -r '.exceeds_200k_tokens // false')
 RL5_RAW=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // 0')
 RL7_RAW=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // 0')
 RL5=$(printf '%.0f' "$RL5_RAW")
@@ -94,6 +97,33 @@ ELAPSED_FMT=$(fmt_dur "$ELAPSED_S")
 API_FMT=$(fmt_dur "$API_S")
 TIME_PART="${DIM}⊙${R} ${ELAPSED_FMT} ${DIM}(api ${API_FMT})${R}"
 
+# Session duration.
+SESSION_PART=""
+if [ "$TOTAL_DURATION_MS" -gt 0 ] 2>/dev/null; then
+  SESS_MINS=$((TOTAL_DURATION_MS / 60000))
+  if [ "$SESS_MINS" -lt 1 ]; then
+    SESSION_PART="${DIM}session <1m${R}"
+  elif [ "$SESS_MINS" -lt 60 ]; then
+    SESSION_PART="${DIM}session ${SESS_MINS}m${R}"
+  else
+    SESS_H=$((SESS_MINS / 60))
+    SESS_M=$((SESS_MINS % 60))
+    SESSION_PART="${DIM}session ${SESS_H}h${SESS_M}m${R}"
+  fi
+fi
+
+# Lines changed.
+LINES_PART=""
+if [ "$LINES_ADD" -gt 0 ] || [ "$LINES_DEL" -gt 0 ]; then
+  LINES_PART="${GREEN}+${LINES_ADD}${R} ${RED}-${LINES_DEL}${R}"
+fi
+
+# Large context warning.
+WARN_PART=""
+if [ "$EXCEEDS_200K" = "true" ]; then
+  WARN_PART="${RED}${BOLD}⚠ >200k${R}"
+fi
+
 # Rate limits (only show when >0%).
 RL_PART=""
 if [ "$RL5" -gt 0 ] || [ "$RL7" -gt 0 ]; then
@@ -140,12 +170,10 @@ MODEL_PART=""
 
 CWD_PART=""
 GIT_PART=""
-PR_PART=""
 if [ -n "$CWD" ]; then
   CWD_SHORT="${CWD/#$HOME/\~}"
   CWD_PART="${CYAN}${CWD_SHORT}${R}"
   BRANCH=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
-  [ -n "$BRANCH" ] && GIT_PART="${DIM}(${BRANCH})${R}"
 
   # Active PR for current branch, cached briefly to avoid statusline latency.
   if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "develop" ] && [ "$BRANCH" != "HEAD" ] && command -v gh >/dev/null 2>&1; then
@@ -170,9 +198,13 @@ if [ -n "$CWD" ]; then
       REPO_URL=$(git -C "$CWD" remote get-url origin 2>/dev/null | sed 's|git@github.com:|https://github.com/|;s|\.git$||' || true)
       if [ -n "$REPO_URL" ]; then
         PR_URL="${REPO_URL}/pull/${PR_NUM}"
-        PR_PART=" ${CYAN}\033]8;;${PR_URL}\033\\PR #${PR_NUM}\033]8;;\033\\${R}"
+        GIT_PART="${DIM}(${BRANCH} ${R}${CYAN}\033]8;;${PR_URL}\033\\#${PR_NUM}\033]8;;\033\\${R}${DIM})${R}"
       fi
     fi
+  fi
+
+  if [ -n "$BRANCH" ] && [ -z "$GIT_PART" ]; then
+    GIT_PART="${DIM}(${BRANCH})${R}"
   fi
 fi
 
@@ -180,11 +212,14 @@ ROW1=""
 [ -n "$MODEL_PART" ] && ROW1="${MODEL_PART}"
 [ -n "$CWD_PART" ] && ROW1="${ROW1} | ${CWD_PART}"
 [ -n "$GIT_PART" ] && ROW1="${ROW1} ${GIT_PART}"
-[ -n "$PR_PART" ] && ROW1="${ROW1}${PR_PART}"
 [ -n "$PLUGIN_PART" ] && ROW1="${ROW1} | ${PLUGIN_PART}"
 
 # Row 2: usage, tokens, cost, timing, limits.
-ROW2="${BAR_C}${BAR}${R} ${BAR_C}${PCT}%${R} | ${DIM}in:${IN_FMT} out:${OUT_FMT} cr:${CR_FMT} cw:${CW_FMT}${R} | ${GOLD}${COST_FMT}${R}"
+ROW2="${BAR_C}${BAR}${R} ${BAR_C}${PCT}%${R}"
+[ -n "$WARN_PART" ] && ROW2="${ROW2} ${WARN_PART}"
+ROW2="${ROW2} | ${DIM}in:${IN_FMT} out:${OUT_FMT} cr:${CR_FMT} cw:${CW_FMT}${R} | ${GOLD}${COST_FMT}${R}"
 ROW2="${ROW2} | ${TIME_PART}${RL_PART}"
+[ -n "$SESSION_PART" ] && ROW2="${ROW2} | ${SESSION_PART}"
+[ -n "$LINES_PART" ] && ROW2="${ROW2} | ${LINES_PART}"
 
 printf '%b\n%b\n' "$ROW1" "$ROW2"

--- a/home-manager/modules/karabiner/default.nix
+++ b/home-manager/modules/karabiner/default.nix
@@ -14,14 +14,16 @@
 # - Profile management
 #
 # Shortcuts:
-# Command + Shift +
-#   Enter -> Alacritty (Terminal)
-#   I     -> IntelliJ IDEA
-#   P     -> PyCharm
-#   S     -> Slack
-#   C     -> Cursor
-#   G     -> Google Chrome
-#   B     -> Brave Browser
+# - Command + Shift + Enter -> Alacritty (Terminal)
+# - Command + Shift + I     -> IntelliJ IDEA
+# - Command + Option + P    -> PyCharm
+# - Command + Shift + S     -> Slack
+# - Command + Shift + C     -> Cursor
+# - Command + Shift + X     -> Codex
+# - Command + Shift + D     -> DataGrip
+# - Command + Shift + A     -> Calendar
+# - Command + Shift + G     -> Google Chrome
+# - Command + Shift + B     -> Brave Browser
 #
 # Integration:
 # - Works with macOS application management
@@ -31,11 +33,12 @@
 # Note:
 # - Requires Karabiner-Elements to be installed (homebrew.nix)
 # - Configuration stored in ~/.config/karabiner/
-{lib, ...}: {
+{ lib, ... }:
+{
   # Karabiner Complete Configuration
   # Sets up configuration with custom modifications included
   home.file.".config/karabiner/karabiner.json" = {
-    force = true;  # Skip backup - we're managing this file declaratively
+    force = true; # Skip backup - we're managing this file declaratively
     text = builtins.toJSON {
       global = {
         check_for_updates_on_startup = true;
@@ -49,7 +52,7 @@
         {
           name = "Default";
           selected = true;
-          simple_modifications = [];
+          simple_modifications = [ ];
           virtual_hid_keyboard = {
             keyboard_type_v2 = "iso";
           };
@@ -66,8 +69,11 @@
                     from = {
                       key_code = "return_or_enter";
                       modifiers = {
-                        mandatory = ["command" "shift"];
-                        optional = ["any"];
+                        mandatory = [
+                          "command"
+                          "shift"
+                        ];
+                        optional = [ "any" ];
                       };
                     };
                     to = [
@@ -86,8 +92,11 @@
                     from = {
                       key_code = "i";
                       modifiers = {
-                        mandatory = ["command" "shift"];
-                        optional = ["any"];
+                        mandatory = [
+                          "command"
+                          "shift"
+                        ];
+                        optional = [ "any" ];
                       };
                     };
                     to = [
@@ -106,8 +115,11 @@
                     from = {
                       key_code = "p";
                       modifiers = {
-                        mandatory = ["command" "option"];
-                        optional = ["any"];
+                        mandatory = [
+                          "command"
+                          "option"
+                        ];
+                        optional = [ "any" ];
                       };
                     };
                     to = [
@@ -126,8 +138,11 @@
                     from = {
                       key_code = "s";
                       modifiers = {
-                        mandatory = ["command" "shift"];
-                        optional = ["any"];
+                        mandatory = [
+                          "command"
+                          "shift"
+                        ];
+                        optional = [ "any" ];
                       };
                     };
                     to = [
@@ -146,13 +161,85 @@
                     from = {
                       key_code = "c";
                       modifiers = {
-                        mandatory = ["command" "shift"];
-                        optional = ["any"];
+                        mandatory = [
+                          "command"
+                          "shift"
+                        ];
+                        optional = [ "any" ];
                       };
                     };
                     to = [
                       {
                         shell_command = "osascript -e 'tell application \"Cursor\" to activate'";
+                      }
+                    ];
+                  }
+                ];
+              }
+              {
+                description = "Open Codex with Command + Shift + X";
+                manipulators = [
+                  {
+                    type = "basic";
+                    from = {
+                      key_code = "x";
+                      modifiers = {
+                        mandatory = [
+                          "command"
+                          "shift"
+                        ];
+                        optional = [ "any" ];
+                      };
+                    };
+                    to = [
+                      {
+                        shell_command = "osascript -e 'tell application \"Codex\" to activate'";
+                      }
+                    ];
+                  }
+                ];
+              }
+              {
+                description = "Open DataGrip with Command + Shift + D";
+                manipulators = [
+                  {
+                    type = "basic";
+                    from = {
+                      key_code = "d";
+                      modifiers = {
+                        mandatory = [
+                          "command"
+                          "shift"
+                        ];
+                        optional = [ "any" ];
+                      };
+                    };
+                    to = [
+                      {
+                        shell_command = "osascript -e 'tell application \"DataGrip\" to activate'";
+                      }
+                    ];
+                  }
+                ];
+              }
+              {
+                description = "Open Calendar with Command + Shift + A";
+                manipulators = [
+                  {
+                    type = "basic";
+                    from = {
+                      key_code = "a";
+                      modifiers = {
+                        mandatory = [
+                          "command"
+                          "shift"
+                        ];
+                        optional = [ "any" ];
+                      };
+                    };
+                    to = [
+                      {
+                        shell_command = "osascript -e 'tell application \"Calendar\" to activate'";
                       }
                     ];
                   }
@@ -166,8 +253,11 @@
                     from = {
                       key_code = "g";
                       modifiers = {
-                        mandatory = ["command" "shift"];
-                        optional = ["any"];
+                        mandatory = [
+                          "command"
+                          "shift"
+                        ];
+                        optional = [ "any" ];
                       };
                     };
                     to = [
@@ -186,8 +276,11 @@
                     from = {
                       key_code = "b";
                       modifiers = {
-                        mandatory = ["command" "shift"];
-                        optional = ["any"];
+                        mandatory = [
+                          "command"
+                          "shift"
+                        ];
+                        optional = [ "any" ];
                       };
                     };
                     to = [

--- a/home-manager/modules/tmux.nix
+++ b/home-manager/modules/tmux.nix
@@ -48,7 +48,10 @@
 # - Uses Ctrl+a prefix
 # - Mouse mode enabled
 # - Vi keys supported
-{ pkgs, ... }:
+{ config, pkgs, ... }:
+let
+  statusScript = "${config.home.homeDirectory}/.config/tmux/status-right.sh";
+in
 {
   programs.tmux = {
     enable = true;
@@ -69,6 +72,8 @@
       set -g mouse on
       set -g status on
       set -g status-position top
+      set -g status-interval 5
+      set -g status-right-length 220
       set -g default-terminal "screen-256color"
       set -ag terminal-overrides ",xterm-256color:RGB"
       set -g allow-passthrough all
@@ -104,6 +109,179 @@
       set -g @tmux-gruvbox 'dark'
       set -g @continuum-restore 'on'
       set -g @resurrect-capture-pane-contents 'on'
+
+      # Status modules
+      set -g status-right "#(${statusScript})"
+    '';
+  };
+
+  home.file.".config/tmux/status-right.sh" = {
+    executable = true;
+    text = ''
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            # Detect connection: wifi (en0) or ethernet (en4/en5/en6)
+            conn_type="offline"
+            ssid="offline"
+            if ipconfig getifaddr en0 >/dev/null 2>&1; then
+              conn_type="wifi"
+              ssid="wifi"
+            else
+              for eth in en4 en5 en6; do
+                if ipconfig getifaddr "$eth" >/dev/null 2>&1; then
+                  conn_type="ethernet"
+                  ssid="ethernet"
+                  break
+                fi
+              done
+            fi
+
+            vpn="$(
+              tailscale status --json 2>/dev/null \
+                | python3 -c "import sys,json; d=json.load(sys.stdin); print('on' if d.get('BackendState') == 'Running' else 'off')" \
+                2>/dev/null || echo "off"
+            )"
+
+
+            disk="$(df -h / 2>/dev/null | awk 'NR==2{print $4" "$5}'  || echo "n/a")"
+            [ -n "$disk" ] || disk="n/a"
+
+            # Network throughput: delta bytes vs previous sample stored in /tmp
+            net="$(python3 -c "
+      import subprocess, time, os
+
+      cache='/tmp/tmux_net_cache'
+      def get_bytes():
+          out = subprocess.run(['netstat','-ib'], capture_output=True, text=True).stdout
+          for line in out.split('\n'):
+              if line.startswith('en0') and '<Link#' in line:
+                  parts = line.split()
+                  try: return int(parts[6]), int(parts[9]), time.time()
+                  except: pass
+          return 0, 0, time.time()
+
+      rx2, tx2, t2 = get_bytes()
+      try:
+          with open(cache) as f:
+              parts = f.read().split()
+              rx1, tx1, t1 = int(parts[0]), int(parts[1]), float(parts[2])
+          dt = max(t2 - t1, 1)
+          rx_kb = (rx2 - rx1) / dt / 1024
+          tx_kb = (tx2 - tx1) / dt / 1024
+          def fmt(k):
+              return f'{k/1024:.1f}M' if k >= 1024 else f'{k:.0f}K'
+          result = f'↓{fmt(rx_kb)} ↑{fmt(tx_kb)}'
+      except:
+          result = '...'
+      with open(cache, 'w') as f:
+          f.write(f'{rx2} {tx2} {t2}')
+      print(result)
+      " 2>/dev/null || echo "n/a")"
+
+            cpu="$(
+              top -l 1 2>/dev/null \
+                | awk -F'[:,%]' '/CPU usage/ { gsub(/^ +| +$/, "", $2); gsub(/^ +| +$/, "", $4); printf "%.0f%%", $2 + $4; exit }' \
+                || true
+            )"
+            [ -n "$cpu" ] || cpu="n/a"
+
+            mem="$(
+              vm_stat 2>/dev/null | awk '
+                /page size of/ { pageSize = $8 }
+                /Pages active/ { active = $3 }
+                /Pages inactive/ { inactive = $3 }
+                /Pages speculative/ { speculative = $3 }
+                /Pages wired down/ { wired = $4 }
+                END {
+                  gsub(/\./, "", active);
+                  gsub(/\./, "", inactive);
+                  gsub(/\./, "", speculative);
+                  gsub(/\./, "", wired);
+                  used = (active + inactive + speculative + wired) * pageSize / 1024 / 1024 / 1024;
+                  if (used > 0) {
+                    printf "%.1fG", used;
+                  }
+                }
+              ' \
+              || true
+            )"
+            [ -n "$mem" ] || mem="n/a"
+
+            battery="$(
+              pmset -g batt 2>/dev/null \
+                | awk -F';' '/%/ { gsub(/^ +| +$/, "", $1); sub(/^.*\t/, "", $1); print $1; exit }' \
+                || true
+            )"
+            [ -n "$battery" ] || battery="n/a"
+
+            battery_charging="$(
+              pmset -g batt 2>/dev/null \
+                | awk '/AC Power/ { ac=1 } /charged|charging/ { if (ac && !/dischar/) print "yes"; exit }' \
+                || true
+            )"
+
+            cpu_color="#b8bb26"
+            cpu_value="''${cpu%%%}"
+            if [ "$cpu_value" != "$cpu" ] && [ "$cpu_value" -ge 80 ] 2>/dev/null; then
+              cpu_color="#fb4934"
+            elif [ "$cpu_value" != "$cpu" ] && [ "$cpu_value" -ge 50 ] 2>/dev/null; then
+              cpu_color="#fabd2f"
+            fi
+
+            battery_color="#b8bb26"
+            battery_value="''${battery%%%}"
+            if [ "$battery_value" != "$battery" ] && [ "$battery_value" -le 20 ] 2>/dev/null; then
+              battery_color="#fb4934"
+            elif [ "$battery_value" != "$battery" ] && [ "$battery_value" -le 50 ] 2>/dev/null; then
+              battery_color="#fabd2f"
+            fi
+
+            if [ "$battery_charging" = "yes" ]; then
+              batt_icon="󰂄"
+            else
+              batt_icon="󰁹"
+            fi
+
+            vpn_icon="󰖂"  # 󰖂 VPN lock icon
+            vpn_color="#928374"
+            if [ "$vpn" = "on" ]; then
+              vpn_color="#b8bb26"
+            fi
+
+            case "$conn_type" in
+              wifi)
+                wifi_icon="󰖩"
+                wifi_color="#8ec07c"
+                ;;
+              ethernet)
+                wifi_icon="󰈀"
+                wifi_color="#83a598"
+                ;;
+              offline)
+                wifi_icon="󰖪"
+                wifi_color="#928374"
+                ;;
+            esac
+
+            segment() {
+              local bg="$1"
+              local fg="$2"
+              local prev_bg="$3"
+              local text="$4"
+              printf '#[fg=%s,bg=%s,nobold,nounderscore,noitalics]#[fg=%s,bg=%s] %s ' "$bg" "$prev_bg" "$fg" "$bg" "$text"
+            }
+
+            printf '%s%s%s%s%s%s%s%s%s#[default]' \
+              "$(segment "#3c3836" "#83a598" "#1d2021" "$net")" \
+              "$(segment "#504945" "$wifi_color" "#3c3836" "$wifi_icon $ssid")" \
+              "$(segment "#3c3836" "$vpn_color" "#504945" "$vpn_icon $vpn")" \
+              "$(segment "#504945" "#a89984" "#3c3836" "󰋊 $disk")" \
+              "$(segment "#3c3836" "$cpu_color" "#504945" " $cpu")" \
+              "$(segment "#504945" "#ebdbb2" "#3c3836" " $mem")" \
+              "$(segment "#3c3836" "$battery_color" "#504945" "$batt_icon $battery")" \
+              "$(segment "#504945" "#d5c4a1" "#3c3836" "$(date "+%H:%M")")" \
+              "$(segment "#bdae93" "#3c3836" "#504945" "$(hostname -s)")"
     '';
   };
 }


### PR DESCRIPTION
## Summary
- add Claude Code aliases cc, ccc, and ccr
- add Karabiner shortcuts for Codex, DataGrip, and Calendar, and update shortcut docs
- align Claude Code defaults/statusline with stable shared settings
- restore richer tmux status metrics with compact styled segments

## Validation
- nix run nixpkgs#nixfmt -- home-manager/config/claude.nix home-manager/modules/karabiner/default.nix home-manager/aliases/dev-tools.nix home-manager/modules/tmux.nix
- bash -n home-manager/modules/claude-code/statusline.sh
- nix flake check --no-build
- evaluated Claude Code settings.default.json: Sonnet 4.6, low effort, 16384 max output tokens
- evaluated generated Karabiner rules and rendered a sample Claude statusline