### PR TITLE
[codex] Clean up stale documentation references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ Start Here → Architecture → Configuration → Advanced Topics
 
 - [System Architecture](technical/architecture.md)
 - [Troubleshooting](technical/troubleshooting.md)
-- [Alias System Improvements](../home-manager/aliases/IMPROVEMENTS.md) - How aliases evolved
+- [Refactoring Backlog](refactoring-backlog.md) - Current cleanup backlog
 
 ## 📚 Reference Documentation
 
@@ -174,42 +174,39 @@ docs/
 ├── guides/                      ← Step-by-step guides
 │   ├── system-overview.md
 │   ├── configuration-basics.md
+│   ├── package-management.md
+│   ├── git-setup.md
+│   ├── aws-sso-setup.md
 │   ├── lazywarden-recovery.md
 │   ├── toolchain-ownership.md
 │   ├── personalization.md
-│   ├── development-setup.md
-│   ├── terminal-setup.md
-│   ├── performance.md
-│   ├── monitoring.md
-│   └── security.md
+│   └── terminal-setup.md
 ├── development/                 ← Developer-focused docs
 │   ├── environment-templates.md
 │   ├── python-setup.md
 │   └── cloud-setup.md
 ├── customization/              ← Customization guides
+│   ├── modules.md
+│   ├── packages.md
+│   ├── stylix-optimization.md
 │   ├── themes.md
-│   ├── paths.md
-│   └── shortcuts.md
+│   └── paths.md
 ├── performance/                ← Performance optimization
 │   └── rebuild-optimization.md
 ├── monitoring/                 ← System monitoring
 │   └── system-health.md
-├── reference/                  ← Reference materials
-│   ├── aliases.md
-│   ├── scripts.md
-│   └── configuration-files.md
 ├── technical/                  ← Deep technical docs
 │   ├── architecture.md
-│   ├── troubleshooting.md
-│   └── nix-concepts.md
+│   └── troubleshooting.md
 ├── advanced/                   ← Advanced topics
 │   ├── impermanence-evaluation.md
 │   ├── secrets-management-analysis.md
 │   └── nur-integration-analysis.md
+├── testing/                    ← Validation docs
+│   └── onboarding-test-plan.md
 └── help/                       ← Support and help
     ├── faq.md
-    ├── troubleshooting.md
-    └── community.md
+    └── troubleshooting.md
 ```
 
 ## 🏃‍♂️ Too Busy? Quick Links

--- a/docs/development/environment-templates.md
+++ b/docs/development/environment-templates.md
@@ -490,6 +490,6 @@ To add new templates:
 ## Resources
 
 - [direnv Documentation](https://direnv.net/)
-- [Development Environment Best Practices](../core/configuration.md)
+- [Configuration Basics](../guides/configuration-basics.md)
 - [Tool Configuration](../customization/packages.md)
-- [Troubleshooting Guide](../core/troubleshooting.md)
+- [Troubleshooting Guide](../help/troubleshooting.md)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -156,9 +156,9 @@ echo $SHELL
 
 After successful installation, you can:
 
-1. Review the [Configuration Guide](configuration.md)
-2. Check [Troubleshooting](troubleshooting.md) if needed
-3. Explore available [Tools](../tools/git.md)
+1. Review the [Configuration Guide](../guides/configuration-basics.md)
+2. Check [Troubleshooting](../help/troubleshooting.md) if needed
+3. Explore [Git & GitHub Setup](../guides/git-setup.md)
 
 ## Uninstallation
 

--- a/docs/guides/system-overview.md
+++ b/docs/guides/system-overview.md
@@ -87,7 +87,7 @@ darwin/
 ```text
 home-manager/
 ├── default.nix           # Main user config
-├── aliases.nix           # Shell shortcuts
+├── aliases/              # Shell shortcuts grouped by domain
 ├── neovim.nix           # Editor config
 └── modules/             # Individual tool configs
     ├── alacritty/       # Terminal
@@ -208,7 +208,7 @@ dotfile/
 │   └── *.nix             # Other system modules
 ├── home-manager/          # User-level configuration
 │   ├── default.nix       # Main user config
-│   ├── aliases.nix       # Shell shortcuts
+│   ├── aliases/          # Shell shortcuts grouped by domain
 │   └── modules/          # Tool-specific configs
 ├── scripts/               # Automation scripts
 │   ├── monitoring/
@@ -318,7 +318,7 @@ Now that you understand the architecture:
 - **[Configuration Basics](configuration-basics.md)** - Learn to modify your setup
 - **[Personalization Guide](personalization.md)** - Make it yours
 - **[Development Setup](../development/environment-templates.md)** - Set up coding environments
-- **[Performance Guide](performance.md)** - Optimize your system
+- **[Performance Guide](../performance/rebuild-optimization.md)** - Optimize your system
 
 ---
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -216,7 +216,7 @@ See: [Development Environment Templates](../development/environment-templates.md
 3. **Test thoroughly**
 4. **Submit pull request**
 
-See: [Contributing Guidelines](contributing.md)
+See the repository pull request flow and run the checks in [Quick Reference](../getting-started/quick-reference.md).
 
 ### Q: Is this production-ready?
 
@@ -232,4 +232,4 @@ See: [Contributing Guidelines](contributing.md)
 - **Documentation**: [Complete Guide Index](../README.md)
 - **Issues**: Open an issue in your fork/repository
 - **Troubleshooting**: [Technical Guide](../technical/troubleshooting.md)
-- **Community**: [Nix Community Resources](community.md)
+- **Community**: [NixOS Discourse](https://discourse.nixos.org/) and [nix-darwin](https://github.com/nix-darwin/nix-darwin)

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -90,7 +90,7 @@ darwin/
 ```text
 home-manager/
 ├── default.nix           # Main entry point
-├── aliases.nix           # Shell shortcuts and functions
+├── aliases/              # Shell shortcuts grouped by domain
 ├── neovim.nix           # Editor configuration
 └── modules/             # Individual application configs
     ├── alacritty/       # Terminal emulator

--- a/home-manager/modules/git.nix
+++ b/home-manager/modules/git.nix
@@ -19,7 +19,7 @@
 #
 # Note:
 # - Identity from active host profile (email can also come from local includeIf)
-# - Additional aliases in aliases.nix
+# - Additional shell aliases live under ../aliases/
 { ... }@args:
 let
   inherit (args) fullName email signingKey;
@@ -104,6 +104,6 @@ in
     ];
   };
 
-  # Shell Integration Aliases moved to aliases.nix
+  # Shell integration aliases live under aliases/
   # ZSH functions moved to zsh.nix
 }

--- a/home-manager/modules/github.nix
+++ b/home-manager/modules/github.nix
@@ -19,7 +19,8 @@
 # Note:
 # - Auth via 'gh auth login'
 # - Additional git config in git.nix
-{...}: {
+{ ... }:
+{
   programs.gh = {
     enable = true;
     settings = {
@@ -32,5 +33,5 @@
 
   # Custom GitHub Workflow Functions moved to zsh.nix
 
-  # GitHub Command Aliases moved to aliases.nix
+  # GitHub command aliases live under aliases/
 }

--- a/home-manager/modules/karabiner/default.nix
+++ b/home-manager/modules/karabiner/default.nix
@@ -31,7 +31,7 @@
 # - Supports multiple profiles and devices
 #
 # Note:
-# - Requires Karabiner-Elements to be installed (homebrew.nix)
+# - Requires Karabiner-Elements to be installed via Homebrew casks
 # - Configuration stored in ~/.config/karabiner/
 { lib, ... }:
 {

--- a/home-manager/scripts/README.md
+++ b/home-manager/scripts/README.md
@@ -288,5 +288,5 @@ All scripts have error checking built in. Common issues:
 ## 📚 Further Reading
 
 - See `../aliases/README.md` for complete alias documentation
-- See `../aliases/IMPROVEMENTS.md` for development history
+- See `../../docs/refactoring-backlog.md` for current cleanup context
 - Check individual script headers for detailed documentation


### PR DESCRIPTION
## Summary
- update docs maps to match the files that actually exist
- replace stale links to removed docs with current guides
- refresh old aliases.nix comments after the aliases module split
- clarify Karabiner dependency wording

## Validation
- nix flake check --no-build
- nixfmt on touched Nix files
- stale-reference grep for removed docs paths and aliases.nix references
- Markdown link check across non-archive docs