### PR TITLE
Refactor dotfile ownership and status modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The repository is organized into logical, optimized components:
   - Modular program configurations with helper functions
   - Lazy-loaded AWS SSO functions for fast startup
   - Package-only CLI groups under `home-manager/modules/packages/`
+  - Profile-aware behavior through `home-manager/config/profile.nix`
   - Personal preferences and tools
   - Shell and terminal setup
 
@@ -111,6 +112,12 @@ The repository is organized into logical, optimized components:
   - Basic Nix configuration
   - Shell integration
   - Dynamic configurations
+
+- `docs/architecture/` - Maintainer-facing structure and ownership docs
+  - Repo map, ownership rules, and profile surface
+
+- `docs/runbooks/homelab/` - External homelab operations
+  - Monitoring, Msgvault, Paperless, and service migration procedures
 
 ## Prerequisites
 
@@ -345,8 +352,14 @@ dotfile/
 │   └── profiles/               # Work/personal Homebrew overrides
 ├── home-manager/
 │   ├── default.nix             # User environment entry point
+│   ├── aliases/                # Shell aliases split by ownership
+│   ├── config/                 # Shared declarative facts
 │   ├── modules/package-groups.nix
+│   ├── scripts/                # Home Manager-installed helper scripts
 │   └── modules/packages/       # Package-only Home Manager CLI groups
+├── docs/
+│   ├── architecture/           # Repo map, ownership, profile surface
+│   └── runbooks/homelab/       # External homelab operating procedures
 ├── scripts/                    # Organized scripts
 │   ├── install/
 │   │   ├── pre-nix-installation.sh    # Installation script
@@ -369,7 +382,7 @@ rebuild   # Uses hostname resolved from active host in hosts.nix
           # Optional: rebuild --work | rebuild --personal
 rebuild-work      # Explicit work target
 rebuild-personal  # Explicit personal target
-update    # Update flake inputs and rebuild
+update    # Update Homebrew metadata/packages, flake inputs, and rebuild
 cleanup   # Clean old Nix generations
 ```
 
@@ -387,8 +400,10 @@ ghprc     # Checkout PR
 ghprl     # List PRs
 
 # Cloud (lazy-loaded for fast startup)
-awsp      # Switch AWS profile
-awsf      # Ultimate AWS workflow
+awsd      # Default/dev SSO + file credentials
+awsp      # Production/prod SSO + file credentials
+awsrd     # Refresh default/dev SSO + file credentials
+awsrp     # Refresh production/prod SSO + file credentials
 ```
 
 ## Documentation

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,9 @@ Follow this sequence to master your dotfiles configuration:
 
 ### Level 3: Advanced Topics
 
+- **[Repo Map](architecture/dotfile-map.md)** - How the repository is organized
+- **[Ownership Rules](architecture/ownership-rules.md)** - Where each kind of change belongs
+- **[Profile Surface](architecture/profile-surface.md)** - Work vs personal profile behavior
 - **[Performance Optimization](performance/rebuild-optimization.md)** - Speed up your system
 - **[System Monitoring](monitoring/system-health.md)** - Health checks and maintenance
 - **[Alias System](../home-manager/aliases/README.md)** - Complete alias reference (~220 total)
@@ -80,14 +83,31 @@ Start Here → System Overview → Performance → Monitoring
 Start Here → Architecture → Configuration → Advanced Topics
 ```
 
+- [Repo Map](architecture/dotfile-map.md)
+- [Ownership Rules](architecture/ownership-rules.md)
+- [Profile Surface](architecture/profile-surface.md)
 - [System Architecture](technical/architecture.md)
 - [Troubleshooting](technical/troubleshooting.md)
 - [Refactoring Backlog](refactoring-backlog.md) - Current cleanup backlog
+
+### 🏠 I Want to Operate the Homelab
+
+```text
+Start Here → Homelab Runbooks → Service-Specific Checks
+```
+
+- [Homelab Runbooks](runbooks/homelab/README.md)
+- [Monitoring LXC](runbooks/homelab/monitoring.md)
+- [Msgvault](runbooks/homelab/msgvault.md)
+- [Paperless-ngx](runbooks/homelab/paperlessng.md)
 
 ## 📚 Reference Documentation
 
 ### Quick Access
 
+- **[Repo Map](architecture/dotfile-map.md)** - Maintainer map of the repo
+- **[Ownership Rules](architecture/ownership-rules.md)** - Placement rules for future changes
+- **[Profile Surface](architecture/profile-surface.md)** - Work/personal behavior
 - **[Alias System](../home-manager/aliases/README.md)** - Complete alias reference (~220 total)
 - **[Scripts Guide](../home-manager/scripts/README.md)** - Helper scripts documentation
 - **[Lazywarden Recovery](guides/lazywarden-recovery.md)** - Decrypt Lazywarden backup archives
@@ -167,6 +187,10 @@ See: [Workflow Aliases](../home-manager/aliases/README.md#workflow-shortcuts)
 ```text
 docs/
 ├── README.md                    ← You are here!
+├── architecture/                ← Maintainer map and ownership rules
+│   ├── dotfile-map.md
+│   ├── ownership-rules.md
+│   └── profile-surface.md
 ├── getting-started/             ← New users start here
 │   ├── installation.md
 │   ├── first-steps.md
@@ -204,6 +228,12 @@ docs/
 │   └── nur-integration-analysis.md
 ├── testing/                    ← Validation docs
 │   └── onboarding-test-plan.md
+├── runbooks/                   ← External operational procedures
+│   └── homelab/
+│       ├── README.md
+│       ├── monitoring.md
+│       ├── msgvault.md
+│       └── paperlessng.md
 └── help/                       ← Support and help
     ├── faq.md
     └── troubleshooting.md

--- a/docs/architecture/dotfile-map.md
+++ b/docs/architecture/dotfile-map.md
@@ -1,0 +1,77 @@
+# Dotfile Map
+
+This repository is the workstation control plane. It configures macOS, Home
+Manager, shell UX, development tools, work credentials, and homelab access.
+Operational procedures belong in runbooks unless they are reusable local
+workstation automation.
+
+## Core Workstation
+
+- `flake.nix`, `flake.lock` - flake inputs and host outputs.
+- `hosts.nix`, `hosts.example.nix`, `lib/hosts.nix` - user and host inventory.
+- `darwin/` - nix-darwin system configuration, macOS defaults, Homebrew, and
+  system-level services.
+- `home-manager/default.nix` - Home Manager entrypoint and import wiring.
+
+## Shell And Terminal UX
+
+- `home-manager/modules/zsh.nix` - zsh Home Manager options and small shell
+  functions.
+- `home-manager/scripts/zsh-integration.zsh` - interactive zsh behavior.
+- `home-manager/modules/starship.nix` - prompt configuration.
+- `home-manager/modules/tmux.nix` - tmux wiring and status script installation.
+- `home-manager/scripts/tmux/status/` - tmux status modules.
+- `home-manager/modules/alacritty/` - terminal configuration.
+
+## Aliases
+
+- `home-manager/aliases/` - short interactive entrypoints.
+- Aliases should stay thin. Multi-step behavior belongs in scripts.
+
+## Packages And Programs
+
+- `home-manager/modules/package-groups.nix` - package group imports.
+- `home-manager/modules/packages/` - Home Manager-owned CLI packages.
+- `home-manager/modules/programs/` - program-specific configuration.
+- `darwin/homebrew-packages/` - Homebrew-owned GUI apps, casks, taps, and
+  toolchains that are better managed by Homebrew on macOS.
+
+## Work Profile
+
+- `darwin/profiles/work.nix` - work-specific system/Homebrew choices.
+- `home-manager/config/aws.nix` - AWS account/profile naming.
+- `home-manager/modules/aws-sso.nix` - declarative AWS config wiring.
+- `home-manager/scripts/aws-sso.zsh` - AWS SSO and credentials workflow.
+- `home-manager/scripts/work.zsh` - work shell helpers.
+
+## Personal Profile
+
+- `darwin/profiles/personal.nix` - personal machine system/Homebrew choices.
+- Profile-specific behavior should live behind profile modules instead of being
+  mixed into shared modules.
+
+## Homelab Access
+
+- `home-manager/config/ssh.nix` - homelab host inventory.
+- `home-manager/modules/ssh.nix` - SSH client config generated from inventory.
+- `home-manager/aliases/homelab.nix` - short homelab entrypoints.
+- `home-manager/modules/msgvault.nix` and `home-manager/scripts/msgvault-*` -
+  reusable local msgvault client integration.
+
+## Runbooks And Operational Artifacts
+
+- `docs/runbooks/homelab/` - procedures for external systems such as monitoring,
+  Grafana, Paperless, Uptime Kuma, and Proxmox.
+- `Grafana_dashboards/` - dashboard and alerting source artifacts. These are not
+  workstation config, but they are tracked here as homelab operational assets.
+
+## Testing And Guardrails
+
+- `scripts/testing/` - smoke tests and repository guardrails.
+- `.github/workflows/onboarding-checks.yml` - GitHub onboarding checks.
+- `nix flake check --no-build` - primary Nix evaluation check.
+
+## Archive
+
+- `docs/archive/` - historical analysis and superseded documentation. Files here
+  should not be treated as current instructions.

--- a/docs/architecture/ownership-rules.md
+++ b/docs/architecture/ownership-rules.md
@@ -1,0 +1,50 @@
+# Ownership Rules
+
+These rules keep the dotfiles useful without letting one-off work turn into
+permanent clutter.
+
+## Repository Purpose
+
+The repository configures the local workstation and exposes reusable workflows.
+It should not become the source of truth for every external system operation.
+
+## Module Responsibilities
+
+- Nix modules configure state.
+- Shell scripts execute behavior.
+- Aliases expose tiny entrypoints.
+- Docs explain workflows.
+- Runbooks operate external systems.
+- Secrets are encrypted or generated locally, never committed in plaintext.
+
+## Promotion Rules
+
+A one-off command can become a script only when it is expected to be reused.
+A script can become a Home Manager module only when it needs declarative files,
+packages, activation, or profile-aware wiring.
+An external-system procedure belongs in `docs/runbooks/` unless it must run from
+the local workstation repeatedly.
+
+## Profile Rules
+
+Shared modules must stay profile-neutral. Work-only behavior belongs behind the
+work profile or a clearly work-gated module. Personal machines should not inherit
+work-specific labels, credentials, or VPN assumptions.
+
+## Alias Rules
+
+Aliases should be short and memorable. They should not hide long workflows with
+stateful side effects. Put multi-step behavior in `home-manager/scripts/` and
+make the alias call that script.
+
+## Tmux Status Rules
+
+The tmux status bar may show machine/session state, not per-command details that
+already appear in the shell prompt. Segments should be conditional when possible
+and cheap to compute. Network calls from the status bar are forbidden.
+
+## Documentation Rules
+
+README stays onboarding-first. Deep explanations belong in `docs/`. External
+system operations belong in runbooks. Archived docs must not be linked as current
+guidance.

--- a/docs/architecture/profile-surface.md
+++ b/docs/architecture/profile-surface.md
@@ -1,0 +1,22 @@
+# Profile Surface
+
+This repo has two workstation profiles: `work` and `personal`.
+
+Profile selection starts in `hosts.nix`. Darwin uses that host entry to choose
+Homebrew overrides from `darwin/profiles/`, while Home Manager modules use
+`home-manager/config/profile.nix` for profile-aware behavior.
+
+## Current Work-Only Behavior
+
+- `home-manager/scripts/work.zsh` is sourced only for the work profile.
+- Tmux shows the AWS VPN status segment only for the work profile.
+- Work and personal Homebrew differences belong in `darwin/profiles/work.nix`
+  and `darwin/profiles/personal.nix`.
+
+## Rules
+
+- Shared workstation behavior belongs in common modules, not profile files.
+- Profile files should only describe differences.
+- Home Manager modules should import `home-manager/config/profile.nix` instead
+  of comparing `userConfig.profile` directly.
+- Work-only shell helpers belong in `home-manager/scripts/work.zsh`.

--- a/docs/guides/aws-sso-setup.md
+++ b/docs/guides/aws-sso-setup.md
@@ -503,25 +503,27 @@ These are **not** standard AWS CLI commands, but convenient shortcuts defined in
 | `awsall` | Complete AWS setup | Login to both SSO profiles + export credentials |
 | `awsprod` | Switch to production | Set production-sso profile |
 | `awsdefault` | Switch to default | Set default-sso profile |
-| `awsp` | Production environment | Switch to production + export credentials |
-| `awsd` | Default environment | Switch to default + export credentials |
+| `awsp` | Production environment | Switch to production + export credentials to `production`, `prod`, and `prd` |
+| `awsd` | Default environment | Switch to default + export credentials to `default`, `dev`, `develop`, `development`, `stg`, and `staging` |
 
 #### **SSO Login Commands**
 
 | Alias | Function | Description |
 |-------|----------|-------------|
 | `awsl` | Quick SSO login | Login to both SSO profiles |
-| `awslp` | Login production | Login to production-sso only |
-| `awsld` | Login default | Login to default-sso only |
-| `awslb` | Login both | Login to both profiles |
+| `awsrp` | Refresh production | Login to production-sso and refresh `production`, `prod`, and `prd` in `~/.aws/credentials` |
+| `awsrd` | Refresh default | Login to default-sso and refresh `default`, `dev`, `develop`, `development`, `stg`, and `staging` in `~/.aws/credentials` |
+| `awsrs` | Refresh staging | Login to staging-sso only |
+| `awsr` | Refresh both | Login to both SSO profiles |
 
 #### **Credential Management**
 
 | Alias | Function | Description |
 |-------|----------|-------------|
 | `awse` | Export credentials | Export current profile to environment variables |
-| `awsef` | Export to file | Export credentials to ~/.aws/credentials |
-| `awsb` | Export both profiles | Export both profiles to credentials file |
+| `awsef` | Export to file | Export credentials to one named profile in `~/.aws/credentials` without replacing unrelated profiles |
+| `awsb` | Export both profiles | Export default and production profile groups to credentials file |
+| `awsgroups` | Show credential groups | Print the dev/prod profile names that `awsd`, `awsrd`, `awsp`, and `awsrp` write |
 | `awsc` | Clear credentials | Clear all AWS credentials and sessions |
 
 #### **Utility Commands**

--- a/docs/runbooks/homelab/README.md
+++ b/docs/runbooks/homelab/README.md
@@ -1,0 +1,24 @@
+# Homelab Runbooks
+
+These runbooks cover external homelab systems that this dotfile can reach, but
+does not fully own.
+
+Use this directory for operational procedures: migrations, recovery steps,
+service checks, and dashboard lifecycle notes. Keep reusable local client
+configuration in Home Manager modules instead.
+
+## Services
+
+- `monitoring` (`192.168.10.27`) - consolidated Prometheus, Grafana,
+  Alertmanager, and Uptime Kuma host.
+- `msgvault` (`192.168.10.25`) - remote mail archive API and TUI backend.
+- `paperlessng` (`192.168.10.20`) - Paperless-ngx document service.
+
+Host aliases are declared in `home-manager/config/ssh.nix`.
+
+## Rule Of Thumb
+
+- If it changes this Mac, put it in Nix/Home Manager.
+- If it changes an LXC or service runtime, put the procedure here.
+- If it is a reusable local command, expose it through `home-manager/aliases`
+  or a script under `home-manager/scripts`.

--- a/docs/runbooks/homelab/monitoring.md
+++ b/docs/runbooks/homelab/monitoring.md
@@ -1,0 +1,51 @@
+# Monitoring LXC
+
+The `monitoring` host is the consolidated observability LXC.
+
+## URLs
+
+- Grafana: `http://192.168.10.27:3000`
+- Prometheus: `http://192.168.10.27:9090`
+- Alertmanager: `http://192.168.10.27:9093`
+- Uptime Kuma: `http://192.168.10.27:3001`
+
+Public hostnames are owned by the reverse proxy, not this dotfile.
+
+## Runtime Layout
+
+The live compose stack is expected under:
+
+```bash
+/root/monitoring
+```
+
+Grafana dashboard source artifacts are tracked in:
+
+```bash
+Grafana_dashboards/
+```
+
+When dashboards are migrated or regenerated, keep source JSON files in the repo
+and provision them into Grafana from files. Avoid treating `grafana.db` as the
+source of truth for dashboard design.
+
+## Basic Checks
+
+```bash
+ssh monitoring
+cd /root/monitoring
+docker compose ps
+docker compose logs --tail=100 grafana prometheus alertmanager uptime-kuma
+```
+
+## Retirement Checks For Old LXCs
+
+Before shutting down an old Grafana, Prometheus, Alertmanager, or Uptime Kuma
+LXC, verify:
+
+- DNS/reverse proxy points at `192.168.10.27`.
+- `docker compose ps` is healthy on `monitoring`.
+- Grafana datasources work.
+- Prometheus targets are up.
+- Alertmanager UI loads and receives alerts.
+- Uptime Kuma push URLs still receive pings.

--- a/docs/runbooks/homelab/msgvault.md
+++ b/docs/runbooks/homelab/msgvault.md
@@ -1,0 +1,39 @@
+# Msgvault
+
+Msgvault is installed locally for client commands, while the archive API runs on
+the `msgvault` LXC.
+
+## Local Commands
+
+- `mv` / `mvt` - open the remote TUI.
+- `mvstats` - show archive stats.
+- `mvp "query"` - search, fuzzy-pick a result, and open the message.
+- `mvat "query"` - same as `mvp`, but biased toward attachment-bearing results.
+- `mva "query"` - pick an account first, then search.
+- `mvhybrid "query"` - API hybrid search.
+- `mvsemantic "query"` - API vector search.
+- `mvrotate` - rotate the encrypted API key locally and on the server.
+- `mvschedule` - reconcile the remote systemd sync timer.
+
+## Secret Model
+
+The API key is stored encrypted in the repo as an age file:
+
+```bash
+home-manager/secrets/msgvault-api-key.age
+```
+
+Local wrappers decrypt it into a temporary file at runtime and delete that file
+when the command exits. The SSH private key at `~/.ssh/nuc_homelab_id_ed25519`
+is the local identity used for age decryption.
+
+## Server Checks
+
+```bash
+ssh msgvault
+systemctl status msgvault.service msgvault-sync.timer msgvault-sync.service
+journalctl -u msgvault.service -u msgvault-sync.service --since today
+```
+
+Use `mvhealth`, `mvscheduler`, and `mvvector` from the Mac for quick client-side
+checks.

--- a/docs/runbooks/homelab/paperlessng.md
+++ b/docs/runbooks/homelab/paperlessng.md
@@ -1,0 +1,28 @@
+# Paperless-ngx
+
+The `paperlessng` SSH alias points at the Paperless-ngx LXC.
+
+## Basic Checks
+
+```bash
+ssh paperlessng
+docker ps
+docker compose ps
+docker compose logs --tail=100
+```
+
+If the browser shows `Bad Request (400)`, check Paperless host/origin settings
+and reverse proxy headers first. Paperless commonly rejects requests when the
+public hostname is not present in its allowed host or CSRF origin settings.
+
+## Empty-Instance Reset
+
+Only use this if the instance has no data worth keeping.
+
+1. Stop the Paperless stack.
+2. Remove the app database and media volumes/directories.
+3. Start the stack.
+4. Create a fresh admin user from inside the webserver container.
+
+Prefer creating a new admin user over deleting data when documents already
+exist.

--- a/flake.nix
+++ b/flake.nix
@@ -83,12 +83,15 @@
       mkDarwinConfiguration =
         validatedConfig:
         darwin.lib.darwinSystem {
-          inherit system;
           specialArgs = {
             userConfig = validatedConfig;
             inherit nixpkgsConfig self;
           };
           modules = [
+            {
+              nixpkgs.hostPlatform = system;
+            }
+
             # Core System Modules
             # Base darwin configuration
             ./darwin/configuration.nix

--- a/home-manager/aliases/dev-tools.nix
+++ b/home-manager/aliases/dev-tools.nix
@@ -1,179 +1,23 @@
 # home-manager/aliases/dev-tools.nix
 #
-# Development Tools Aliases
+# Development tool aliases.
 #
-# Purpose:
-# - Docker container management
-# - Terraform/Infrastructure workflows
-# - Kubernetes/k3s operations
-# - FZF-powered tool integration
-#
-# Categories:
-# - Docker (d, dc, dsp, drm, dlog)
-# - Terraform (tf, tfin, tfp, tfa)
-# - Kubernetes (k, kgp, kgs, klogs)
-# - FZF utilities (fe, fcd, fif)
+# This file is intentionally only an aggregator. Keep each tool family in its
+# own module so daily aliases stay easy to scan and refactor safely.
 { helpers, ... }:
 let
-  inherit (helpers) mkAliases mkFileTypeAliases;
+  modernCliAliases = import ./dev-tools/modern-cli.nix { };
+  agentAliases = import ./dev-tools/agents.nix { };
+  tmuxAliases = import ./dev-tools/tmux.nix { };
+  fzfAliases = import ./dev-tools/fzf.nix { };
+  dockerAliases = import ./dev-tools/docker.nix { };
+  terraformAliases = import ./dev-tools/terraform.nix { };
+  kubernetesAliases = import ./dev-tools/kubernetes.nix { };
 in
-{
-  # ==========================================================================
-  # Modern CLI Tool Aliases (eza, fd, duf, btm)
-  # ==========================================================================
-
-  # eza (modern ls replacement)
-  lsa = "eza -la"; # List all with details
-  lst = "eza -T"; # Tree view
-  lsta = "eza -Ta"; # Tree view including hidden files
-  lsr = "eza -R"; # Recursive listing
-  lsg = "eza -l --git"; # List with git status indicators
-  lsm = "eza -l --sort=modified"; # Sort by modification time
-  lss = "eza -l --sort=size"; # Sort by file size
-  lsh = "eza -la --header"; # List with column headers
-  lstree = "eza -T --level=3"; # Tree view (3 levels deep)
-
-  # fd (modern find replacement)
-  fdh = "fd -H"; # Include hidden files - usage: fdh pattern
-  fa = "fd -a"; # Show absolute paths - usage: fa pattern
-  ft = "fd -tf --changed-within 1d"; # Find files modified in last 24h
-  fdir = "fd -td"; # Find directories only - usage: fdir pattern
-  ff = "fd -tf"; # Find files only - usage: ff pattern
-  fsym = "fd -tl"; # Find symlinks only
-  fconf = "fd -e conf -e config"; # Find config files
-  # File type shortcuts
-  fpy = "fd -e py"; # Find Python files - usage: fpy pattern
-  fjs = "fd -e js"; # Find JavaScript files - usage: fjs pattern
-  fnix = "fd -e nix"; # Find Nix files - usage: fnix pattern
-  fsh = "fd -e sh"; # Find shell scripts
-  fmd = "fd -e md"; # Find markdown files
-  fjson = "fd -e json"; # Find JSON files
-  fyaml = "fd -e yaml"; # Find YAML files
-  ftoml = "fd -e toml"; # Find TOML files
-
-  # duf (modern df replacement)
-  dfa = "duf --all"; # Show all filesystems
-  dfh = "duf --hide-fs tmpfs,devtmpfs,efivarfs"; # Hide temporary filesystems
-  dfi = "duf --only local,network"; # Show only local and network disks
-  dfs = "duf --sort size"; # Sort by disk size
-
-  # btm (modern top replacement)
-  bm = "btm --basic"; # Basic system monitor view
-  bmp = "btm --process_command"; # Show full process commands
-  bmt = "btm --tree"; # Show process tree
-  bmb = "btm --battery"; # Show battery info
-  bmn = "btm --network_legend"; # Show network legend
-
-  # ==========================================================================
-  # Claude Code
-  # ==========================================================================
-  cc = "claude"; # Claude Code shorthand
-  ccc = "claude --continue"; # Continue the latest Claude Code conversation
-  ccr = "claude --resume"; # Resume a Claude Code conversation
-
-  # ==========================================================================
-  # Tmux Session Management
-  # ==========================================================================
-  tn = "tmux new -s"; # Create new named session - usage: tn mysession
-  ta = "tmux attach -t"; # Attach to session - usage: ta mysession
-  tl = "tmux list-sessions"; # List all sessions
-  tk = "tmux kill-session -t"; # Kill specific session - usage: tk mysession
-  t = "tmux new-session -A -s main"; # Attach to or create main session
-  tls = "tmux list-sessions -F '#{session_name}: #{?session_attached,attached,not attached}'"; # List sessions with status
-  tkall = "tmux list-sessions -F '#{session_name}' | xargs -I {} tmux kill-session -t {}"; # Kill all sessions
-
-  # ==========================================================================
-  # FZF Integration
-  # ==========================================================================
-  # File editing with preview
-  fe = "fzf --preview 'bat --color=always --style=numbers --line-range=:500 {}' | xargs -r \${EDITOR:-nvim}"; # Fuzzy find and edit file
-  ffp = "fzf --preview 'bat --color=always --style=numbers --line-range=:500 {}'"; # Fuzzy find with file preview
-  edit = "fzf --preview 'bat --color=always {}' | xargs nvim"; # Fuzzy find and edit in nvim
-
-  # Directory navigation
-  fcd = "cd $(find . -type d -not -path '*/\\.*' | fzf)"; # Fuzzy find directory (excluding hidden)
-  fcdh = "cd $(find . -type d | fzf)"; # Fuzzy find directory (including hidden)
-
-  # Content search
-  fif = "rg --color=always --line-number --no-heading --smart-case \"\" | fzf --ansi --preview 'bat --color=always --style=numbers {1} --highlight-line {2}'"; # Fuzzy search file contents
-
-  # Process management
-  fkill = "ps -ef | sed 1d | fzf -m | awk '{print $2}' | xargs kill"; # Fuzzy select and gracefully terminate processes
-  fmem = "ps -eo pid,ppid,cmd,%mem,%cpu --sort=-%mem | head -20 | fzf --header-lines=1"; # Fuzzy browse top memory usage
-
-  # History and environment
-  hist = "history 0 | fzf --ansi --preview 'echo {}' | sed 's/ *[0-9]* *//'"; # Fuzzy search command history
-  fenv = "env | fzf --preview 'echo {}' | cut -d= -f2"; # Fuzzy search environment variables
-
-  # ==========================================================================
-  # Docker
-  # ==========================================================================
-  d = "docker"; # Docker shorthand
-  dc = "docker-compose"; # Docker Compose shorthand
-
-  # Interactive container management
-  dsp = "docker ps --format 'table {{.Names}}\\t{{.Status}}\\t{{.Ports}}' | fzf --header-lines=1 | awk '{print $1}' | xargs -r docker stop"; # Fuzzy select and stop container
-  drm = "docker ps -a --format 'table {{.Names}}\\t{{.Status}}\\t{{.Ports}}' | fzf --header-lines=1 | awk '{print $1}' | xargs -r docker rm"; # Fuzzy select and remove container
-  dimg = "docker images --format 'table {{.Repository}}\\t{{.Tag}}\\t{{.Size}}' | fzf --header-lines=1"; # Fuzzy browse docker images
-  dlog = "docker ps --format 'table {{.Names}}\\t{{.Status}}' | fzf --header-lines=1 | awk '{print $1}' | xargs -r docker logs -f"; # Fuzzy select and tail container logs
-  dexec = "docker ps --format 'table {{.Names}}\\t{{.Status}}' | fzf --header-lines=1 | awk '{print $1}' | xargs -r -I {} docker exec -it {} /bin/bash"; # Fuzzy select and exec into container
-
-  # ==========================================================================
-  # Terraform
-  # ==========================================================================
-  tf = "terraform"; # Terraform shorthand
-  tfin = "terraform init"; # Initialize Terraform
-  tfp = "terraform plan"; # Show execution plan
-  tfa = "terraform apply"; # Apply changes
-  tfd = "terraform destroy"; # Destroy infrastructure
-
-  # Workspace management
-  tfwst = "terraform workspace select"; # Switch workspace
-  tfwsw = "terraform workspace show"; # Show current workspace
-  tfwls = "terraform workspace list"; # List workspaces
-  tfwsn = "terraform workspace new"; # Create new workspace
-
-  # State and planning
-  tfpd = "terraform plan -destroy"; # Plan infrastructure destruction
-  tfsh = "terraform show"; # Show state or plan
-  tfst = "terraform state list"; # List resources in state
-
-  # ==========================================================================
-  # Kubernetes / k3s
-  # ==========================================================================
-  k = "kubectl"; # Kubectl shorthand
-  kgp = "kubectl get pods"; # List pods
-  kgs = "kubectl get svc"; # List services
-  kgd = "kubectl get deployments"; # List deployments
-  kgn = "kubectl get nodes"; # List nodes
-  kga = "kubectl get all"; # List all resources
-  kgns = "kubectl get namespaces"; # List namespaces
-
-  # Describe resources
-  kdp = "kubectl describe pod"; # Describe pod - usage: kdp pod-name
-  kds = "kubectl describe svc"; # Describe service - usage: kds service-name
-  kdd = "kubectl describe deployment"; # Describe deployment - usage: kdd deployment-name
-  kdn = "kubectl describe node"; # Describe node - usage: kdn node-name
-
-  # Logs and exec
-  klogs = "kubectl logs -f"; # Follow pod logs - usage: klogs pod-name
-  kexec = "kubectl exec -it"; # Execute command in pod - usage: kexec pod-name -- /bin/sh
-
-  # Context and namespace
-  kctx = "kubectl config get-contexts"; # List contexts
-  kns = "kubectl config set-context --current --namespace"; # Switch namespace - usage: kns namespace-name
-  ksd = "kubectl config use-context vortexa-develop"; # Switch to Develop context
-  ksp = "kubectl config use-context vortexa-production"; # Switch to Production context
-
-  # Apply and delete
-  kaf = "kubectl apply -f"; # Apply configuration file - usage: kaf deployment.yaml
-  kdf = "kubectl delete -f"; # Delete resources from file - usage: kdf deployment.yaml
-
-  # Port forwarding
-  kpf = "kubectl port-forward"; # Forward port to local machine - usage: kpf pod-name 8080:80
-
-  # Interactive pod selection
-  kfp = "kubectl get pods | fzf --header-lines=1 | awk '{print $1}'"; # Fuzzy select pod
-  kfl = "kubectl get pods | fzf --header-lines=1 | awk '{print $1}' | xargs kubectl logs -f"; # Fuzzy select and tail pod logs
-  kfe = "kubectl get pods | fzf --header-lines=1 | awk '{print $1}' | xargs -I {} kubectl exec -it {} -- /bin/sh"; # Fuzzy select and exec into pod
-}
+modernCliAliases
+// agentAliases
+// tmuxAliases
+// fzfAliases
+// dockerAliases
+// terraformAliases
+// kubernetesAliases

--- a/home-manager/aliases/dev-tools/agents.nix
+++ b/home-manager/aliases/dev-tools/agents.nix
@@ -1,0 +1,23 @@
+# home-manager/aliases/dev-tools/agents.nix
+#
+# Aliases for interactive coding agents and agent CLIs.
+{ ... }:
+let
+  aws = import ../../config/aws.nix;
+in
+{
+  # Claude Code
+  cc = "claude"; # Claude Code shorthand
+  ccc = "claude --continue"; # Continue the latest Claude Code conversation
+  ccr = "claude --resume"; # Resume a Claude Code conversation
+
+  # OpenCode
+  oc = "opencode"; # OpenCode shorthand
+  occ = "opencode run --continue"; # Continue last OpenCode session
+  ocx = "opencode run"; # Execute opencode with a message (non-interactive)
+
+  # Pi Coding Agent
+  pil = "pi --provider lmstudio --model google/gemma-4-26b-a4b"; # Use Gemma 4 26B from LM Studio
+  pig = "pi --provider lmstudio --model google/gemma-4-26b-a4b"; # Gemma shorthand
+  pib = "AWS_PROFILE=${aws.profiles.default} AWS_REGION=${aws.region} pi --provider amazon-bedrock --model eu.anthropic.claude-sonnet-4-6"; # Use Anthropic Claude Sonnet via Bedrock
+}

--- a/home-manager/aliases/dev-tools/docker.nix
+++ b/home-manager/aliases/dev-tools/docker.nix
@@ -1,0 +1,15 @@
+# home-manager/aliases/dev-tools/docker.nix
+#
+# Docker and Docker Compose aliases.
+{ ... }:
+{
+  d = "docker"; # Docker shorthand
+  dc = "docker-compose"; # Docker Compose shorthand
+
+  # Interactive container management
+  dsp = "docker ps --format 'table {{.Names}}\\t{{.Status}}\\t{{.Ports}}' | fzf --header-lines=1 | awk '{print $1}' | xargs -r docker stop"; # Fuzzy select and stop container
+  drm = "docker ps -a --format 'table {{.Names}}\\t{{.Status}}\\t{{.Ports}}' | fzf --header-lines=1 | awk '{print $1}' | xargs -r docker rm"; # Fuzzy select and remove container
+  dimg = "docker images --format 'table {{.Repository}}\\t{{.Tag}}\\t{{.Size}}' | fzf --header-lines=1"; # Fuzzy browse docker images
+  dlog = "docker ps --format 'table {{.Names}}\\t{{.Status}}' | fzf --header-lines=1 | awk '{print $1}' | xargs -r docker logs -f"; # Fuzzy select and tail container logs
+  dexec = "docker ps --format 'table {{.Names}}\\t{{.Status}}' | fzf --header-lines=1 | awk '{print $1}' | xargs -r -I {} docker exec -it {} /bin/bash"; # Fuzzy select and exec into container
+}

--- a/home-manager/aliases/dev-tools/fzf.nix
+++ b/home-manager/aliases/dev-tools/fzf.nix
@@ -1,0 +1,25 @@
+# home-manager/aliases/dev-tools/fzf.nix
+#
+# FZF-powered interactive aliases.
+{ ... }:
+{
+  # File editing with preview
+  fe = "fzf --preview 'bat --color=always --style=numbers --line-range=:500 {}' | xargs -r \${EDITOR:-nvim}"; # Fuzzy find and edit file
+  ffp = "fzf --preview 'bat --color=always --style=numbers --line-range=:500 {}'"; # Fuzzy find with file preview
+  edit = "fzf --preview 'bat --color=always {}' | xargs nvim"; # Fuzzy find and edit in nvim
+
+  # Directory navigation
+  fcd = "cd $(find . -type d -not -path '*/\\.*' | fzf)"; # Fuzzy find directory (excluding hidden)
+  fcdh = "cd $(find . -type d | fzf)"; # Fuzzy find directory (including hidden)
+
+  # Content search
+  fif = "rg --color=always --line-number --no-heading --smart-case \"\" | fzf --ansi --preview 'bat --color=always --style=numbers {1} --highlight-line {2}'"; # Fuzzy search file contents
+
+  # Process management
+  fkill = "ps -ef | sed 1d | fzf -m | awk '{print $2}' | xargs kill"; # Fuzzy select and gracefully terminate processes
+  fmem = "ps -eo pid,ppid,cmd,%mem,%cpu --sort=-%mem | head -20 | fzf --header-lines=1"; # Fuzzy browse top memory usage
+
+  # History and environment
+  hist = "history 0 | fzf --ansi --preview 'echo {}' | sed 's/ *[0-9]* *//'"; # Fuzzy search command history
+  fenv = "env | fzf --preview 'echo {}' | cut -d= -f2"; # Fuzzy search environment variables
+}

--- a/home-manager/aliases/dev-tools/kubernetes.nix
+++ b/home-manager/aliases/dev-tools/kubernetes.nix
@@ -1,0 +1,41 @@
+# home-manager/aliases/dev-tools/kubernetes.nix
+#
+# Kubernetes and k3s aliases.
+{ ... }:
+{
+  k = "kubectl"; # Kubectl shorthand
+  kgp = "kubectl get pods"; # List pods
+  kgs = "kubectl get svc"; # List services
+  kgd = "kubectl get deployments"; # List deployments
+  kgn = "kubectl get nodes"; # List nodes
+  kga = "kubectl get all"; # List all resources
+  kgns = "kubectl get namespaces"; # List namespaces
+
+  # Describe resources
+  kdp = "kubectl describe pod"; # Describe pod - usage: kdp pod-name
+  kds = "kubectl describe svc"; # Describe service - usage: kds service-name
+  kdd = "kubectl describe deployment"; # Describe deployment - usage: kdd deployment-name
+  kdn = "kubectl describe node"; # Describe node - usage: kdn node-name
+
+  # Logs and exec
+  klogs = "kubectl logs -f"; # Follow pod logs - usage: klogs pod-name
+  kexec = "kubectl exec -it"; # Execute command in pod - usage: kexec pod-name -- /bin/sh
+
+  # Context and namespace
+  kctx = "kubectl config get-contexts"; # List contexts
+  kns = "kubectl config set-context --current --namespace"; # Switch namespace - usage: kns namespace-name
+  ksd = "kubectl config use-context vortexa-develop"; # Switch to Develop context
+  ksp = "kubectl config use-context vortexa-production"; # Switch to Production context
+
+  # Apply and delete
+  kaf = "kubectl apply -f"; # Apply configuration file - usage: kaf deployment.yaml
+  kdf = "kubectl delete -f"; # Delete resources from file - usage: kdf deployment.yaml
+
+  # Port forwarding
+  kpf = "kubectl port-forward"; # Forward port to local machine - usage: kpf pod-name 8080:80
+
+  # Interactive pod selection
+  kfp = "kubectl get pods | fzf --header-lines=1 | awk '{print $1}'"; # Fuzzy select pod
+  kfl = "kubectl get pods | fzf --header-lines=1 | awk '{print $1}' | xargs kubectl logs -f"; # Fuzzy select and tail pod logs
+  kfe = "kubectl get pods | fzf --header-lines=1 | awk '{print $1}' | xargs -I {} kubectl exec -it {} -- /bin/sh"; # Fuzzy select and exec into pod
+}

--- a/home-manager/aliases/dev-tools/modern-cli.nix
+++ b/home-manager/aliases/dev-tools/modern-cli.nix
@@ -1,0 +1,48 @@
+# home-manager/aliases/dev-tools/modern-cli.nix
+#
+# Aliases for modern replacements of common Unix tools.
+{ ... }:
+{
+  # eza (modern ls replacement)
+  lsa = "eza -la"; # List all with details
+  lst = "eza -T"; # Tree view
+  lsta = "eza -Ta"; # Tree view including hidden files
+  lsr = "eza -R"; # Recursive listing
+  lsg = "eza -l --git"; # List with git status indicators
+  lsm = "eza -l --sort=modified"; # Sort by modification time
+  lss = "eza -l --sort=size"; # Sort by file size
+  lsh = "eza -la --header"; # List with column headers
+  lstree = "eza -T --level=3"; # Tree view (3 levels deep)
+
+  # fd (modern find replacement)
+  fdh = "fd -H"; # Include hidden files - usage: fdh pattern
+  fa = "fd -a"; # Show absolute paths - usage: fa pattern
+  ft = "fd -tf --changed-within 1d"; # Find files modified in last 24h
+  fdir = "fd -td"; # Find directories only - usage: fdir pattern
+  ff = "fd -tf"; # Find files only - usage: ff pattern
+  fsym = "fd -tl"; # Find symlinks only
+  fconf = "fd -e conf -e config"; # Find config files
+
+  # File type shortcuts
+  fpy = "fd -e py"; # Find Python files - usage: fpy pattern
+  fjs = "fd -e js"; # Find JavaScript files - usage: fjs pattern
+  fnix = "fd -e nix"; # Find Nix files - usage: fnix pattern
+  fsh = "fd -e sh"; # Find shell scripts
+  fmd = "fd -e md"; # Find markdown files
+  fjson = "fd -e json"; # Find JSON files
+  fyaml = "fd -e yaml"; # Find YAML files
+  ftoml = "fd -e toml"; # Find TOML files
+
+  # duf (modern df replacement)
+  dfa = "duf --all"; # Show all filesystems
+  dfh = "duf --hide-fs tmpfs,devtmpfs,efivarfs"; # Hide temporary filesystems
+  dfi = "duf --only local,network"; # Show only local and network disks
+  dfs = "duf --sort size"; # Sort by disk size
+
+  # btm (modern top replacement)
+  bm = "btm --basic"; # Basic system monitor view
+  bmp = "btm --process_command"; # Show full process commands
+  bmt = "btm --tree"; # Show process tree
+  bmb = "btm --battery"; # Show battery info
+  bmn = "btm --network_legend"; # Show network legend
+}

--- a/home-manager/aliases/dev-tools/terraform.nix
+++ b/home-manager/aliases/dev-tools/terraform.nix
@@ -1,0 +1,22 @@
+# home-manager/aliases/dev-tools/terraform.nix
+#
+# Terraform workflow aliases.
+{ ... }:
+{
+  tf = "terraform"; # Terraform shorthand
+  tfin = "terraform init"; # Initialize Terraform
+  tfp = "terraform plan"; # Show execution plan
+  tfa = "terraform apply"; # Apply changes
+  tfd = "terraform destroy"; # Destroy infrastructure
+
+  # Workspace management
+  tfwst = "terraform workspace select"; # Switch workspace
+  tfwsw = "terraform workspace show"; # Show current workspace
+  tfwls = "terraform workspace list"; # List workspaces
+  tfwsn = "terraform workspace new"; # Create new workspace
+
+  # State and planning
+  tfpd = "terraform plan -destroy"; # Plan infrastructure destruction
+  tfsh = "terraform show"; # Show state or plan
+  tfst = "terraform state list"; # List resources in state
+}

--- a/home-manager/aliases/dev-tools/tmux.nix
+++ b/home-manager/aliases/dev-tools/tmux.nix
@@ -1,0 +1,13 @@
+# home-manager/aliases/dev-tools/tmux.nix
+#
+# Tmux session management aliases.
+{ ... }:
+{
+  tn = "tmux new -s"; # Create new named session - usage: tn mysession
+  ta = "tmux attach -t"; # Attach to session - usage: ta mysession
+  tl = "tmux list-sessions"; # List all sessions
+  tk = "tmux kill-session -t"; # Kill specific session - usage: tk mysession
+  t = "tmux new-session -A -s main"; # Attach to or create main session
+  tls = "tmux list-sessions -F '#{session_name}: #{?session_attached,attached,not attached}'"; # List sessions with status
+  tkall = "tmux list-sessions -F '#{session_name}' | xargs -I {} tmux kill-session -t {}"; # Kill all sessions
+}

--- a/home-manager/config/profile.nix
+++ b/home-manager/config/profile.nix
@@ -1,0 +1,15 @@
+# home-manager/config/profile.nix
+#
+# Shared profile helpers for Home Manager modules.
+#
+# Keep profile checks here instead of scattering string comparisons through
+# modules. Host selection still lives in hosts.nix.
+{ userConfig }:
+let
+  name = userConfig.profile or "personal";
+in
+{
+  inherit name;
+  isWork = name == "work";
+  isPersonal = name == "personal";
+}

--- a/home-manager/modules/opencode.nix
+++ b/home-manager/modules/opencode.nix
@@ -1,0 +1,49 @@
+# home-manager/modules/opencode.nix
+#
+# OpenCode LM Studio provider configuration.
+#
+# OpenCode and LM Studio are installed through Homebrew. This module
+# intentionally skips configuration until both are present so rebuilds stay safe
+# on machines that have not installed those tools yet.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  opencodeConfig = "${config.home.homeDirectory}/.config/opencode/opencode.json";
+in
+{
+  home.activation.configureOpenCodeLMStudio = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    if ! command -v opencode >/dev/null 2>&1 || [ ! -d "/Applications/LM Studio.app" ]; then
+      echo "OpenCode/LM Studio not installed; skipping OpenCode LM Studio config."
+      exit 0
+    fi
+
+    mkdir -p "$(dirname "${opencodeConfig}")"
+    if [ ! -s "${opencodeConfig}" ]; then
+      printf '%s\n' '{}' > "${opencodeConfig}"
+    fi
+
+    tmp="$(mktemp)"
+    ${pkgs.jq}/bin/jq '
+      ."$schema" = (.["$schema"] // "https://opencode.ai/config.json")
+      | .provider.lmstudio = {
+          "npm": "@ai-sdk/openai-compatible",
+          "name": "LM Studio (local)",
+          "options": {
+            "baseURL": "http://localhost:1234/v1"
+          },
+          "models": {
+            "google/gemma-4-26b-a4b": {
+              "name": "Gemma 4 26B"
+            }
+          }
+        }
+      | .model = (.model // "lmstudio/google/gemma-4-26b-a4b")
+    ' "${opencodeConfig}" > "$tmp"
+    install -m 600 "$tmp" "${opencodeConfig}"
+    rm -f "$tmp"
+  '';
+}

--- a/home-manager/modules/pi.nix
+++ b/home-manager/modules/pi.nix
@@ -1,0 +1,42 @@
+# home-manager/modules/pi.nix
+#
+# Pi Coding Agent local provider configuration.
+#
+# Pi reads custom model providers from ~/.pi/agent/models.json. Keep local model
+# plumbing here so shell aliases only select a provider/model and do not carry
+# fragile JSON or endpoint details.
+{ pkgs, ... }:
+let
+  json = pkgs.formats.json { };
+in
+{
+  home.file.".pi/agent/models.json".source = json.generate "pi-models.json" {
+    providers = {
+      lmstudio = {
+        baseUrl = "http://localhost:1234/v1";
+        api = "openai-completions";
+        apiKey = "lm-studio";
+        compat = {
+          supportsDeveloperRole = false;
+          supportsReasoningEffort = false;
+        };
+        models = [
+          {
+            id = "google/gemma-4-26b-a4b";
+            name = "Gemma 4 26B (LM Studio)";
+            reasoning = true;
+            input = [ "text" ];
+            contextWindow = 128000;
+            maxTokens = 16384;
+            cost = {
+              input = 0;
+              output = 0;
+              cacheRead = 0;
+              cacheWrite = 0;
+            };
+          }
+        ];
+      };
+    };
+  };
+}

--- a/home-manager/modules/tmux.nix
+++ b/home-manager/modules/tmux.nix
@@ -111,7 +111,7 @@ in
       set -g @resurrect-capture-pane-contents 'on'
 
       # Status modules
-      set -g status-right "#(${statusScript})"
+      set -g status-right "#(bash ${statusScript})"
     '';
   };
 
@@ -121,41 +121,70 @@ in
             #!/usr/bin/env bash
             set -euo pipefail
 
-            # Detect connection: wifi (en0) or ethernet (en4/en5/en6)
-            conn_type="offline"
-            ssid="offline"
-            if ipconfig getifaddr en0 >/dev/null 2>&1; then
-              conn_type="wifi"
-              ssid="wifi"
+            default_iface="$(route -n get default 2>/dev/null | awk '/interface:/ { print $2; exit }' || true)"
+            wifi_active="no"
+            lan_active="no"
+            for iface in $(ifconfig -l 2>/dev/null); do
+              case "$iface" in
+                en0)
+                  if ipconfig getifaddr "$iface" >/dev/null 2>&1; then
+                    wifi_active="yes"
+                  fi
+                  ;;
+                en*)
+                  if ipconfig getifaddr "$iface" >/dev/null 2>&1; then
+                    lan_active="yes"
+                  fi
+                  ;;
+              esac
+            done
+
+            if [ "$wifi_active" = "yes" ] && [ "$lan_active" = "yes" ]; then
+              if [ "$default_iface" = "en0" ]; then
+                network_label="󰖩 wifi · 󰈀 lan"
+              else
+                network_label="󰈀 lan · 󰖩 wifi"
+              fi
+              network_color="#8ec07c"
+            elif [ "$lan_active" = "yes" ]; then
+              network_label="󰈀 lan"
+              network_color="#83a598"
+            elif [ "$wifi_active" = "yes" ]; then
+              network_label="󰖩 wifi"
+              network_color="#8ec07c"
             else
-              for eth in en4 en5 en6; do
-                if ipconfig getifaddr "$eth" >/dev/null 2>&1; then
-                  conn_type="ethernet"
-                  ssid="ethernet"
-                  break
-                fi
-              done
+              network_label="󰖪 offline"
+              network_color="#928374"
             fi
 
+            # Show VPN as on when macOS reports any connected VPN service,
+            # including Tailscale.
             vpn="$(
-              tailscale status --json 2>/dev/null \
-                | python3 -c "import sys,json; d=json.load(sys.stdin); print('on' if d.get('BackendState') == 'Running' else 'off')" \
-                2>/dev/null || echo "off"
+              if scutil --nc list 2>/dev/null \
+                | awk '/\(Connected\)/ { found=1 } END { exit found ? 0 : 1 }'; then
+                echo "on"
+              else
+                echo "off"
+              fi
             )"
 
-
-            disk="$(df -h / 2>/dev/null | awk 'NR==2{print $4" "$5}'  || echo "n/a")"
+            disk="$(
+              df -h /System/Volumes/Data / 2>/dev/null \
+                | awk 'NR==2{print $5 " " $3 "/" $2; exit}' \
+                || echo "n/a"
+            )"
             [ -n "$disk" ] || disk="n/a"
 
             # Network throughput: delta bytes vs previous sample stored in /tmp
-            net="$(python3 -c "
-      import subprocess, time, os
+            net="$(DEFAULT_IFACE="$default_iface" python3 -c "
+      import os, subprocess, time
 
-      cache='/tmp/tmux_net_cache'
+      iface=os.environ.get('DEFAULT_IFACE') or 'en0'
+      cache=f'/tmp/tmux_net_cache_{iface}'
       def get_bytes():
           out = subprocess.run(['netstat','-ib'], capture_output=True, text=True).stdout
           for line in out.split('\n'):
-              if line.startswith('en0') and '<Link#' in line:
+              if line.startswith(iface) and '<Link#' in line:
                   parts = line.split()
                   try: return int(parts[6]), int(parts[9]), time.time()
                   except: pass
@@ -167,8 +196,8 @@ in
               parts = f.read().split()
               rx1, tx1, t1 = int(parts[0]), int(parts[1]), float(parts[2])
           dt = max(t2 - t1, 1)
-          rx_kb = (rx2 - rx1) / dt / 1024
-          tx_kb = (tx2 - tx1) / dt / 1024
+          rx_kb = max(rx2 - rx1, 0) / dt / 1024
+          tx_kb = max(tx2 - tx1, 0) / dt / 1024
           def fmt(k):
               return f'{k/1024:.1f}M' if k >= 1024 else f'{k:.0f}K'
           result = f'↓{fmt(rx_kb)} ↑{fmt(tx_kb)}'
@@ -249,21 +278,6 @@ in
               vpn_color="#b8bb26"
             fi
 
-            case "$conn_type" in
-              wifi)
-                wifi_icon="󰖩"
-                wifi_color="#8ec07c"
-                ;;
-              ethernet)
-                wifi_icon="󰈀"
-                wifi_color="#83a598"
-                ;;
-              offline)
-                wifi_icon="󰖪"
-                wifi_color="#928374"
-                ;;
-            esac
-
             segment() {
               local bg="$1"
               local fg="$2"
@@ -274,9 +288,9 @@ in
 
             printf '%s%s%s%s%s%s%s%s%s#[default]' \
               "$(segment "#3c3836" "#83a598" "#1d2021" "$net")" \
-              "$(segment "#504945" "$wifi_color" "#3c3836" "$wifi_icon $ssid")" \
+              "$(segment "#504945" "$network_color" "#3c3836" "$network_label")" \
               "$(segment "#3c3836" "$vpn_color" "#504945" "$vpn_icon $vpn")" \
-              "$(segment "#504945" "#a89984" "#3c3836" "󰋊 $disk")" \
+              "$(segment "#504945" "#a89984" "#3c3836" " $disk")" \
               "$(segment "#3c3836" "$cpu_color" "#504945" " $cpu")" \
               "$(segment "#504945" "#ebdbb2" "#3c3836" " $mem")" \
               "$(segment "#3c3836" "$battery_color" "#504945" "$batt_icon $battery")" \

--- a/home-manager/modules/tmux.nix
+++ b/home-manager/modules/tmux.nix
@@ -48,8 +48,14 @@
 # - Uses Ctrl+a prefix
 # - Mouse mode enabled
 # - Vi keys supported
-{ config, pkgs, ... }:
+{
+  config,
+  pkgs,
+  userConfig,
+  ...
+}:
 let
+  profile = import ../config/profile.nix { inherit userConfig; };
   statusScript = "${config.home.homeDirectory}/.config/tmux/status-right.sh";
 in
 {
@@ -70,6 +76,7 @@ in
     extraConfig = ''
       # Core Settings
       set -g mouse on
+      set -g extended-keys on
       set -g status on
       set -g status-position top
       set -g status-interval 5
@@ -77,7 +84,7 @@ in
       set -g default-terminal "screen-256color"
       set -ag terminal-overrides ",xterm-256color:RGB"
       set -g allow-passthrough all
-      set -g update-environment "DISPLAY KRB5CCNAME SSH_ASKPASS SSH_AUTH_SOCK SSH_AGENT_PID SSH_CONNECTION WINDOWID XAUTHORITY DOCKER_CONFIG"
+      set -g update-environment "DISPLAY KRB5CCNAME SSH_ASKPASS SSH_AUTH_SOCK SSH_AGENT_PID SSH_CONNECTION WINDOWID XAUTHORITY DOCKER_CONFIG AWS_PROFILE AWS_DEFAULT_REGION AWS_REGION"
 
       # Pane Management
       bind h split-window -h -c "#{pane_current_path}"
@@ -115,187 +122,24 @@ in
     '';
   };
 
-  home.file.".config/tmux/status-right.sh" = {
-    executable = true;
-    text = ''
-            #!/usr/bin/env bash
-            set -euo pipefail
+  home.file = {
+    ".config/tmux/status-right.sh" = {
+      text = ''
+        #!/usr/bin/env bash
+        export DOTFILES_TMUX_SHOW_AWS_VPN="${if profile.isWork then "yes" else "no"}"
+        exec bash "$HOME/.config/tmux/status/status-right.sh"
+      '';
+      executable = true;
+    };
 
-            default_iface="$(route -n get default 2>/dev/null | awk '/interface:/ { print $2; exit }' || true)"
-            wifi_active="no"
-            lan_active="no"
-            for iface in $(ifconfig -l 2>/dev/null); do
-              case "$iface" in
-                en0)
-                  if ipconfig getifaddr "$iface" >/dev/null 2>&1; then
-                    wifi_active="yes"
-                  fi
-                  ;;
-                en*)
-                  if ipconfig getifaddr "$iface" >/dev/null 2>&1; then
-                    lan_active="yes"
-                  fi
-                  ;;
-              esac
-            done
-
-            if [ "$wifi_active" = "yes" ] && [ "$lan_active" = "yes" ]; then
-              if [ "$default_iface" = "en0" ]; then
-                network_label="󰖩 wifi · 󰈀 lan"
-              else
-                network_label="󰈀 lan · 󰖩 wifi"
-              fi
-              network_color="#8ec07c"
-            elif [ "$lan_active" = "yes" ]; then
-              network_label="󰈀 lan"
-              network_color="#83a598"
-            elif [ "$wifi_active" = "yes" ]; then
-              network_label="󰖩 wifi"
-              network_color="#8ec07c"
-            else
-              network_label="󰖪 offline"
-              network_color="#928374"
-            fi
-
-            # Show VPN as on when macOS reports any connected VPN service,
-            # including Tailscale.
-            vpn="$(
-              if scutil --nc list 2>/dev/null \
-                | awk '/\(Connected\)/ { found=1 } END { exit found ? 0 : 1 }'; then
-                echo "on"
-              else
-                echo "off"
-              fi
-            )"
-
-            disk="$(
-              df -h /System/Volumes/Data / 2>/dev/null \
-                | awk 'NR==2{print $5 " " $3 "/" $2; exit}' \
-                || echo "n/a"
-            )"
-            [ -n "$disk" ] || disk="n/a"
-
-            # Network throughput: delta bytes vs previous sample stored in /tmp
-            net="$(DEFAULT_IFACE="$default_iface" python3 -c "
-      import os, subprocess, time
-
-      iface=os.environ.get('DEFAULT_IFACE') or 'en0'
-      cache=f'/tmp/tmux_net_cache_{iface}'
-      def get_bytes():
-          out = subprocess.run(['netstat','-ib'], capture_output=True, text=True).stdout
-          for line in out.split('\n'):
-              if line.startswith(iface) and '<Link#' in line:
-                  parts = line.split()
-                  try: return int(parts[6]), int(parts[9]), time.time()
-                  except: pass
-          return 0, 0, time.time()
-
-      rx2, tx2, t2 = get_bytes()
-      try:
-          with open(cache) as f:
-              parts = f.read().split()
-              rx1, tx1, t1 = int(parts[0]), int(parts[1]), float(parts[2])
-          dt = max(t2 - t1, 1)
-          rx_kb = max(rx2 - rx1, 0) / dt / 1024
-          tx_kb = max(tx2 - tx1, 0) / dt / 1024
-          def fmt(k):
-              return f'{k/1024:.1f}M' if k >= 1024 else f'{k:.0f}K'
-          result = f'↓{fmt(rx_kb)} ↑{fmt(tx_kb)}'
-      except:
-          result = '...'
-      with open(cache, 'w') as f:
-          f.write(f'{rx2} {tx2} {t2}')
-      print(result)
-      " 2>/dev/null || echo "n/a")"
-
-            cpu="$(
-              top -l 1 2>/dev/null \
-                | awk -F'[:,%]' '/CPU usage/ { gsub(/^ +| +$/, "", $2); gsub(/^ +| +$/, "", $4); printf "%.0f%%", $2 + $4; exit }' \
-                || true
-            )"
-            [ -n "$cpu" ] || cpu="n/a"
-
-            mem="$(
-              vm_stat 2>/dev/null | awk '
-                /page size of/ { pageSize = $8 }
-                /Pages active/ { active = $3 }
-                /Pages inactive/ { inactive = $3 }
-                /Pages speculative/ { speculative = $3 }
-                /Pages wired down/ { wired = $4 }
-                END {
-                  gsub(/\./, "", active);
-                  gsub(/\./, "", inactive);
-                  gsub(/\./, "", speculative);
-                  gsub(/\./, "", wired);
-                  used = (active + inactive + speculative + wired) * pageSize / 1024 / 1024 / 1024;
-                  if (used > 0) {
-                    printf "%.1fG", used;
-                  }
-                }
-              ' \
-              || true
-            )"
-            [ -n "$mem" ] || mem="n/a"
-
-            battery="$(
-              pmset -g batt 2>/dev/null \
-                | awk -F';' '/%/ { gsub(/^ +| +$/, "", $1); sub(/^.*\t/, "", $1); print $1; exit }' \
-                || true
-            )"
-            [ -n "$battery" ] || battery="n/a"
-
-            battery_charging="$(
-              pmset -g batt 2>/dev/null \
-                | awk '/AC Power/ { ac=1 } /charged|charging/ { if (ac && !/dischar/) print "yes"; exit }' \
-                || true
-            )"
-
-            cpu_color="#b8bb26"
-            cpu_value="''${cpu%%%}"
-            if [ "$cpu_value" != "$cpu" ] && [ "$cpu_value" -ge 80 ] 2>/dev/null; then
-              cpu_color="#fb4934"
-            elif [ "$cpu_value" != "$cpu" ] && [ "$cpu_value" -ge 50 ] 2>/dev/null; then
-              cpu_color="#fabd2f"
-            fi
-
-            battery_color="#b8bb26"
-            battery_value="''${battery%%%}"
-            if [ "$battery_value" != "$battery" ] && [ "$battery_value" -le 20 ] 2>/dev/null; then
-              battery_color="#fb4934"
-            elif [ "$battery_value" != "$battery" ] && [ "$battery_value" -le 50 ] 2>/dev/null; then
-              battery_color="#fabd2f"
-            fi
-
-            if [ "$battery_charging" = "yes" ]; then
-              batt_icon="󰂄"
-            else
-              batt_icon="󰁹"
-            fi
-
-            vpn_icon="󰖂"  # 󰖂 VPN lock icon
-            vpn_color="#928374"
-            if [ "$vpn" = "on" ]; then
-              vpn_color="#b8bb26"
-            fi
-
-            segment() {
-              local bg="$1"
-              local fg="$2"
-              local prev_bg="$3"
-              local text="$4"
-              printf '#[fg=%s,bg=%s,nobold,nounderscore,noitalics]#[fg=%s,bg=%s] %s ' "$bg" "$prev_bg" "$fg" "$bg" "$text"
-            }
-
-            printf '%s%s%s%s%s%s%s%s%s#[default]' \
-              "$(segment "#3c3836" "#83a598" "#1d2021" "$net")" \
-              "$(segment "#504945" "$network_color" "#3c3836" "$network_label")" \
-              "$(segment "#3c3836" "$vpn_color" "#504945" "$vpn_icon $vpn")" \
-              "$(segment "#504945" "#a89984" "#3c3836" " $disk")" \
-              "$(segment "#3c3836" "$cpu_color" "#504945" " $cpu")" \
-              "$(segment "#504945" "#ebdbb2" "#3c3836" " $mem")" \
-              "$(segment "#3c3836" "$battery_color" "#504945" "$batt_icon $battery")" \
-              "$(segment "#504945" "#d5c4a1" "#3c3836" "$(date "+%H:%M")")" \
-              "$(segment "#bdae93" "#3c3836" "#504945" "$(hostname -s)")"
-    '';
+    ".config/tmux/status/lib.sh".source = ../scripts/tmux/status/lib.sh;
+    ".config/tmux/status/network.sh".source = ../scripts/tmux/status/network.sh;
+    ".config/tmux/status/vpn.sh".source = ../scripts/tmux/status/vpn.sh;
+    ".config/tmux/status/aws.sh".source = ../scripts/tmux/status/aws.sh;
+    ".config/tmux/status/system.sh".source = ../scripts/tmux/status/system.sh;
+    ".config/tmux/status/status-right.sh" = {
+      source = ../scripts/tmux/status/status-right.sh;
+      executable = true;
+    };
   };
 }

--- a/home-manager/modules/zsh.nix
+++ b/home-manager/modules/zsh.nix
@@ -9,6 +9,9 @@
   userConfig,
   ...
 }:
+let
+  profile = import ../config/profile.nix { inherit userConfig; };
+in
 {
   programs = {
     zsh = {
@@ -32,8 +35,40 @@
 
       initContent = ''
         source "${../scripts/zsh-integration.zsh}"
+
+        _dotfiles_run_rebuild() {
+          DOTFILE_DIR="${config.home.homeDirectory}/${userConfig.directories.dotfiles}" \
+          CURRENT_CONFIG_HOST="${userConfig.hostname}" \
+          bash "${../scripts/rebuild-system.sh}" "$@" || return $?
+        }
+
+        rebuild() {
+          _dotfiles_run_rebuild "$@"
+        }
+
+        rebuild-work() {
+          rebuild --work "$@"
+        }
+
+        rebuild-personal() {
+          rebuild --personal "$@"
+        }
+
+        update() {
+          local dotfile_dir="${config.home.homeDirectory}/${userConfig.directories.dotfiles}"
+
+          echo "Starting system update..."
+          brew update || return $?
+          brew upgrade || return $?
+
+          cd "$dotfile_dir" || return $?
+          nix flake update || return $?
+          _dotfiles_run_rebuild "$@" || return $?
+
+          echo "System update complete!"
+        }
       ''
-      + lib.optionalString (userConfig.profile == "work") ''
+      + lib.optionalString profile.isWork ''
         source "${../scripts/work.zsh}"
       '';
 

--- a/home-manager/scripts/aws-sso.zsh
+++ b/home-manager/scripts/aws-sso.zsh
@@ -13,6 +13,13 @@ _load_aws_sso() {
   _aws_profile_default="${AWS_SSO_DEFAULT_PROFILE:-default-sso}"
   _aws_profile_production="${AWS_SSO_PRODUCTION_PROFILE:-production-sso}"
   _aws_profile_staging="${AWS_SSO_STAGING_PROFILE:-staging-sso}"
+  _aws_profiles_dev="default dev develop development stg staging"
+  _aws_profiles_prod="production prod prd"
+
+  aws_credential_profile_groups() {
+    echo "dev:  $_aws_profiles_dev"
+    echo "prod: $_aws_profiles_prod"
+  }
 
   # Helper: Parse credentials from AWS CLI env output.
   _aws_credential_value() {
@@ -69,20 +76,122 @@ _load_aws_sso() {
     fi
   }
 
-  # Helper: Write credentials atomically with restrictive permissions.
-  _aws_write_credentials_file() {
-    local content="$1"
+  # Helper: Replace only selected profile sections in ~/.aws/credentials.
+  _aws_upsert_credential_profiles() {
+    local profile_names="$1"
+    local access_key="$2"
+    local secret_key="$3"
+    local session_token="$4"
     local credentials_file="$HOME/.aws/credentials"
     local credentials_dir="$HOME/.aws"
-    local temp_file
+    local temp_file trim_file
 
     mkdir -p "$credentials_dir"
     chmod 700 "$credentials_dir" 2>/dev/null || true
     temp_file="$(mktemp "$credentials_dir/credentials.XXXXXX")" || return 1
     chmod 600 "$temp_file"
-    printf '%s\n' "$content" > "$temp_file"
+
+    if [ -f "$credentials_file" ]; then
+      cp "$credentials_file" "$HOME/.aws/credentials.backup.$(date +%Y%m%d_%H%M%S)"
+      chmod 600 "$HOME/.aws/credentials.backup."* 2>/dev/null || true
+      echo "📋 Backed up existing credentials file"
+
+      awk -v replace_profiles="$profile_names" '
+        BEGIN {
+          split(replace_profiles, names, " ")
+          for (i in names) replace["[" names[i] "]"] = 1
+          skip = 0
+          previous_blank = 0
+        }
+        /^\[[^]]+\][[:space:]]*$/ {
+          skip = ($0 in replace)
+        }
+        !skip {
+          if ($0 == "") {
+            if (!previous_blank) print
+            previous_blank = 1
+          } else {
+            print
+            previous_blank = 0
+          }
+        }
+      ' "$credentials_file" > "$temp_file"
+
+      trim_file="$(mktemp "$credentials_dir/credentials.XXXXXX")" || return 1
+      awk '
+        NF { last = NR }
+        { lines[NR] = $0 }
+        END {
+          for (i = 1; i <= last; i++) print lines[i]
+        }
+      ' "$temp_file" > "$trim_file"
+      mv "$trim_file" "$temp_file"
+
+      # Keep exactly one blank line between preserved content and new sections.
+      [ -s "$temp_file" ] && printf '\n' >> "$temp_file"
+    fi
+
+    local profile_name
+    for profile_name in ${(z)profile_names}; do
+      cat >> "$temp_file" <<EOF
+[$profile_name]
+aws_access_key_id = $access_key
+aws_secret_access_key = $secret_key
+aws_session_token = $session_token
+
+EOF
+    done
+
     mv "$temp_file" "$credentials_file"
     chmod 600 "$credentials_file"
+  }
+
+  # Helper: Parse and write one exported credential set to related profile names.
+  _aws_export_to_profiles() {
+    local source_profile="$1"
+    local profile_names="$2"
+    [ -z "$source_profile" ] && { echo "❌ No profile specified"; return 1; }
+    [ -z "$profile_names" ] && { echo "❌ No target profiles specified"; return 1; }
+
+    echo "📁 Exporting credentials from '$source_profile' to: $profile_names"
+
+    local temp_creds_env export_error export_error_file export_status
+    local attempt max_attempts=5
+    for attempt in {1..5}; do
+      export_error_file="$(mktemp "${TMPDIR:-/tmp}/aws-export-credentials.XXXXXX")" || return 1
+      temp_creds_env=$(aws configure export-credentials --profile "$source_profile" --format env 2>"$export_error_file")
+      export_status=$?
+      export_error="$(cat "$export_error_file")"
+      rm -f "$export_error_file"
+
+      if [ "$export_status" -eq 0 ] && [ -n "$temp_creds_env" ]; then
+        break
+      fi
+
+      [ "$attempt" -lt "$max_attempts" ] && {
+        echo "⏳ Credentials not ready yet for '$source_profile' (attempt $attempt/$max_attempts). Retrying..."
+        sleep 2
+      }
+    done
+
+    if [ -z "$temp_creds_env" ]; then
+      echo "❌ Failed to get credentials for profile '$source_profile'"
+      [ -n "$export_error" ] && echo "   $export_error"
+      echo "💡 Try: aws_sso_login $source_profile"
+      return 1
+    fi
+
+    local access_key secret_key session_token
+    access_key="$(_aws_credential_value "$temp_creds_env" "AWS_ACCESS_KEY_ID")"
+    secret_key="$(_aws_credential_value "$temp_creds_env" "AWS_SECRET_ACCESS_KEY")"
+    session_token="$(_aws_credential_value "$temp_creds_env" "AWS_SESSION_TOKEN")"
+
+    [ -z "$access_key" ] || [ -z "$secret_key" ] || [ -z "$session_token" ] && {
+      echo "❌ Failed to parse credentials"; return 1;
+    }
+
+    _aws_upsert_credential_profiles "$profile_names" "$access_key" "$secret_key" "$session_token" || return 1
+    echo "✅ Credentials written to ~/.aws/credentials for: $profile_names"
   }
 
   # Core SSO login function (single or both).
@@ -164,37 +273,7 @@ _load_aws_sso() {
   aws_export_to_file() {
     local source_profile="${1:-$AWS_PROFILE}"
     local target_profile="${2:-$source_profile}"
-    [ -z "$source_profile" ] && { echo "❌ No profile specified"; return 1; }
-
-    echo "📁 Exporting credentials from '$source_profile' to '$target_profile' in ~/.aws/credentials"
-
-    local temp_creds_env
-    temp_creds_env=$(aws configure export-credentials --profile "$source_profile" --format env 2>/dev/null)
-    if [ $? -ne 0 ] || [ -z "$temp_creds_env" ]; then
-      echo "❌ Failed to get credentials for profile '$source_profile'"
-      echo "💡 Try: aws_sso_login $source_profile"
-      return 1
-    fi
-
-    local access_key secret_key session_token
-    access_key="$(_aws_credential_value "$temp_creds_env" "AWS_ACCESS_KEY_ID")"
-    secret_key="$(_aws_credential_value "$temp_creds_env" "AWS_SECRET_ACCESS_KEY")"
-    session_token="$(_aws_credential_value "$temp_creds_env" "AWS_SESSION_TOKEN")"
-
-    [ -z "$access_key" ] || [ -z "$secret_key" ] || [ -z "$session_token" ] && {
-      echo "❌ Failed to parse credentials"; return 1;
-    }
-
-    [ -f "$HOME/.aws/credentials" ] && {
-      cp "$HOME/.aws/credentials" "$HOME/.aws/credentials.backup.$(date +%Y%m%d_%H%M%S)"
-      chmod 600 "$HOME/.aws/credentials.backup."* 2>/dev/null || true
-      echo "📋 Backed up existing credentials file"
-    }
-
-    _aws_write_credentials_file "[$target_profile]
-aws_access_key_id = $access_key
-aws_secret_access_key = $secret_key
-aws_session_token = $session_token" || return 1
+    _aws_export_to_profiles "$source_profile" "$target_profile" || return 1
 
     echo "✅ Credentials written to ~/.aws/credentials as [$target_profile]"
     local account_id
@@ -206,44 +285,8 @@ aws_session_token = $session_token" || return 1
   # Export both profiles to ~/.aws/credentials file.
   aws_export_both_to_file() {
     echo "📁 Exporting both profiles to ~/.aws/credentials"
-
-    [ -f "$HOME/.aws/credentials" ] && {
-      cp "$HOME/.aws/credentials" "$HOME/.aws/credentials.backup.$(date +%Y%m%d_%H%M%S)"
-      chmod 600 "$HOME/.aws/credentials.backup."* 2>/dev/null || true
-      echo "📋 Backed up existing credentials file"
-    }
-
-    local prod_creds default_creds
-    prod_creds=$(aws configure export-credentials --profile "$_aws_profile_production" --format env 2>/dev/null)
-    default_creds=$(aws configure export-credentials --profile "$_aws_profile_default" --format env 2>/dev/null)
-
-    [ -z "$prod_creds" ] && { echo "❌ Failed to get production credentials"; return 1; }
-    [ -z "$default_creds" ] && { echo "❌ Failed to get default credentials"; return 1; }
-
-    local prod_access prod_secret prod_token default_access default_secret default_token
-    prod_access="$(_aws_credential_value "$prod_creds" "AWS_ACCESS_KEY_ID")"
-    prod_secret="$(_aws_credential_value "$prod_creds" "AWS_SECRET_ACCESS_KEY")"
-    prod_token="$(_aws_credential_value "$prod_creds" "AWS_SESSION_TOKEN")"
-    default_access="$(_aws_credential_value "$default_creds" "AWS_ACCESS_KEY_ID")"
-    default_secret="$(_aws_credential_value "$default_creds" "AWS_SECRET_ACCESS_KEY")"
-    default_token="$(_aws_credential_value "$default_creds" "AWS_SESSION_TOKEN")"
-
-    [ -z "$prod_access" ] || [ -z "$prod_secret" ] || [ -z "$prod_token" ] && {
-      echo "❌ Failed to parse production credentials"; return 1;
-    }
-    [ -z "$default_access" ] || [ -z "$default_secret" ] || [ -z "$default_token" ] && {
-      echo "❌ Failed to parse default credentials"; return 1;
-    }
-
-    _aws_write_credentials_file "[production]
-aws_access_key_id = $prod_access
-aws_secret_access_key = $prod_secret
-aws_session_token = $prod_token
-
-[default]
-aws_access_key_id = $default_access
-aws_secret_access_key = $default_secret
-aws_session_token = $default_token" || return 1
+    _aws_export_to_profiles "$_aws_profile_production" "$_aws_profiles_prod" || return 1
+    _aws_export_to_profiles "$_aws_profile_default" "$_aws_profiles_dev" || return 1
 
     echo "✅ Both profiles written to ~/.aws/credentials"
     echo "🎉 Ready for Scala/Java applications!"
@@ -279,7 +322,7 @@ aws_session_token = $default_token" || return 1
     echo "🚀 Setting production profile and exporting credentials..."
     aws_profile "$_aws_profile_production" && aws_export_creds && {
       echo "📁 Also exporting to ~/.aws/credentials file..."
-      aws_export_to_file "$_aws_profile_production" production
+      _aws_export_to_profiles "$_aws_profile_production" "$_aws_profiles_prod"
     }
   }
 
@@ -287,7 +330,7 @@ aws_session_token = $default_token" || return 1
     echo "🏠 Setting default profile and exporting credentials..."
     aws_profile "$_aws_profile_default" && aws_export_creds && {
       echo "📁 Also exporting to ~/.aws/credentials file..."
-      aws_export_to_file "$_aws_profile_default" default
+      _aws_export_to_profiles "$_aws_profile_default" "$_aws_profiles_dev"
     }
   }
 
@@ -307,11 +350,13 @@ aws_session_token = $default_token" || return 1
   aws_dev() { aws_profile "$_aws_profile_staging"; }
   aws_refresh() { aws_sso_login "${1:-both}"; }
   aws_refresh_both() { aws_sso_login both; }
+  aws_refresh_prod() { aws_sso_login "$_aws_profile_production" && _aws_export_to_profiles "$_aws_profile_production" "$_aws_profiles_prod"; }
+  aws_refresh_default() { aws_sso_login "$_aws_profile_default" && _aws_export_to_profiles "$_aws_profile_default" "$_aws_profiles_dev"; }
   aws_logout() { aws_clear; }
 }
 
 # Lazy wrapper functions that load AWS SSO on first use.
-unalias awsp awsd awse awsef awsf awsc awsl awsr awsw awsb awsall awsprod awsdefault awsprod-trad awsdefault-trad awsrp awsrs awsrd 2>/dev/null || true
+unalias awsp awsd awse awsef awsf awsc awsl awsr awsw awsb awsall awsprod awsdefault awsprod-trad awsdefault-trad awsrp awsrs awsrd awsgroups 2>/dev/null || true
 
 awsp() { _load_aws_sso && aws_prod_env "$@"; }
 awsd() { _load_aws_sso && aws_default_env "$@"; }
@@ -329,6 +374,7 @@ awsprod() { _load_aws_sso && aws_prod "$@"; }
 awsdefault() { _load_aws_sso && aws_profile "${AWS_SSO_DEFAULT_PROFILE:-default-sso}" "$@"; }
 awsprod-trad() { _load_aws_sso && aws_profile production "$@"; }
 awsdefault-trad() { _load_aws_sso && aws_profile default "$@"; }
-awsrp() { _load_aws_sso && aws_sso_login "${AWS_SSO_PRODUCTION_PROFILE:-production-sso}" "$@"; }
+awsrp() { _load_aws_sso && aws_refresh_prod "$@"; }
 awsrs() { _load_aws_sso && aws_sso_login "${AWS_SSO_STAGING_PROFILE:-staging-sso}" "$@"; }
-awsrd() { _load_aws_sso && aws_sso_login "${AWS_SSO_DEFAULT_PROFILE:-default-sso}" "$@"; }
+awsrd() { _load_aws_sso && aws_refresh_default "$@"; }
+awsgroups() { _load_aws_sso && aws_credential_profile_groups "$@"; }

--- a/home-manager/scripts/cleanup-system.sh
+++ b/home-manager/scripts/cleanup-system.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  cleanup           Run regular system cleanup
+  cleanup --docker  Remove unused Docker data, including unused images
+  cleanup --deep    Run regular cleanup plus Docker cleanup
+  cleanup --help    Show this help
+USAGE
+}
+
+confirm() {
+  local prompt="$1"
+  local answer
+  printf "%s [y/N] " "$prompt"
+  read -r answer
+  [[ "$answer" = [Yy] || "$answer" = [Yy][Ee][Ss] ]]
+}
+
+run_regular_cleanup() {
+  echo "Starting regular system cleanup..."
+
+  echo "Running Nix garbage collection..."
+  nix-collect-garbage -d --option max-jobs auto --option cores 0
+  echo "Nix garbage collection complete"
+
+  echo "Cleaning macOS metadata files..."
+  find "$HOME" -type f -name ".DS_Store" -delete 2>/dev/null || true
+  find "$HOME" -type f -name "._*" -delete 2>/dev/null || true
+
+  echo "Cleaning package caches..."
+  if command -v npm >/dev/null 2>&1; then
+    npm cache clean --force 2>/dev/null || true
+  fi
+
+  if command -v brew >/dev/null 2>&1; then
+    brew cleanup --prune=all 2>/dev/null || true
+  fi
+
+  if command -v uv >/dev/null 2>&1; then
+    uv cache clean 2>/dev/null || true
+  elif [ -x "$HOME/.local/bin/uv" ]; then
+    "$HOME/.local/bin/uv" cache clean 2>/dev/null || true
+  fi
+
+  echo "Running Nix store GC..."
+  nix store gc --option max-jobs auto --option cores 0
+
+  echo "Optimizing Nix store..."
+  nix store optimise --option max-jobs auto --option cores 0
+
+  echo "Regular cleanup complete"
+}
+
+print_completion_note() {
+  echo "Cleanup complete. Start a new shell manually if you want to refresh the environment."
+}
+
+run_docker_cleanup() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is not installed or not on PATH."
+    return 0
+  fi
+
+  echo "Cleaning Docker unused data..."
+  docker system prune -a --force
+  echo "Docker cleanup complete"
+}
+
+case "${1:-}" in
+  "")
+    if confirm "Run regular cleanup? This removes old generations and package caches."; then
+      run_regular_cleanup
+      print_completion_note
+    else
+      echo "Cleanup cancelled."
+    fi
+    ;;
+  --docker)
+    if confirm "Run Docker cleanup? This removes all unused images, containers, networks, and build cache."; then
+      run_docker_cleanup
+    else
+      echo "Docker cleanup cancelled."
+    fi
+    ;;
+  --deep)
+    if confirm "Run deep cleanup? This runs regular cleanup plus Docker cleanup."; then
+      run_regular_cleanup
+      run_docker_cleanup
+      print_completion_note
+    else
+      echo "Deep cleanup cancelled."
+    fi
+    ;;
+  --help | -h)
+    usage
+    ;;
+  *)
+    echo "Unknown cleanup option: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/home-manager/scripts/tmux/status/aws.sh
+++ b/home-manager/scripts/tmux/status/aws.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+tmux_status_collect_aws() {
+  aws_profile="$(
+    if command -v tmux >/dev/null 2>&1; then
+      tmux show-environment -g AWS_PROFILE 2>/dev/null | sed 's/^AWS_PROFILE=//' || true
+    fi
+  )"
+  [ -n "$aws_profile" ] || aws_profile="${AWS_PROFILE:-}"
+
+  if [ -z "$aws_profile" ] && awk '/^\[default\]$/ { found=1 } END { exit found ? 0 : 1 }' "$HOME/.aws/credentials" 2>/dev/null; then
+    aws_profile="default"
+  fi
+
+  aws_label=""
+  aws_color="#83a598"
+  case "$aws_profile" in
+    production-sso|production|prod|prd)
+      aws_label="PROD"
+      aws_color="#fb4934"
+      ;;
+    default-sso|default|dev|develop|development|staging-sso|staging|stg)
+      aws_label="DEV"
+      aws_color="#83a598"
+      ;;
+    "")
+      aws_label=""
+      ;;
+    *)
+      aws_label="$aws_profile"
+      aws_color="#928374"
+      ;;
+  esac
+
+  aws_expiry="$(
+    python3 - <<'PY' 2>/dev/null || true
+import datetime as dt
+import glob
+import json
+import os
+
+now = dt.datetime.now(dt.timezone.utc)
+expiries = []
+
+for path in glob.glob(os.path.expanduser("~/.aws/sso/cache/*.json")):
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except Exception:
+        continue
+
+    if "startUrl" not in data:
+        continue
+
+    raw = data.get("expiresAt")
+    if not raw:
+        continue
+
+    try:
+        expires = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        continue
+
+    expiries.append(expires)
+
+if not expiries:
+    raise SystemExit
+
+remaining = int((max(expiries) - now).total_seconds() // 60)
+if remaining <= 0:
+    print("exp")
+elif remaining < 60:
+    print(f"{remaining}m")
+else:
+    hours, minutes = divmod(remaining, 60)
+    print(f"{hours}h" if minutes < 10 else f"{hours}h{minutes}m")
+PY
+  )"
+
+  aws_status=""
+  if [ -n "$aws_label" ]; then
+    aws_status="󰸏 $aws_label"
+    [ -n "$aws_expiry" ] && aws_status="$aws_status $aws_expiry"
+  fi
+
+  if [ "$aws_expiry" = "exp" ]; then
+    aws_color="#fb4934"
+  elif [ -n "$aws_expiry" ] && [ "${aws_expiry%m}" != "$aws_expiry" ] && [ "${aws_expiry%m}" -le 60 ] 2>/dev/null; then
+    aws_color="#fabd2f"
+  fi
+}

--- a/home-manager/scripts/tmux/status/lib.sh
+++ b/home-manager/scripts/tmux/status/lib.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+segment() {
+  local bg="$1"
+  local fg="$2"
+  local prev_bg="$3"
+  local text="$4"
+  printf '#[fg=%s,bg=%s,nobold,nounderscore,noitalics]#[fg=%s,bg=%s] %s ' "$bg" "$prev_bg" "$fg" "$bg" "$text"
+}
+
+append_segment() {
+  local bg="$1"
+  local fg="$2"
+  local text="$3"
+
+  [ -n "$text" ] || return 0
+
+  status_output+=$(segment "$bg" "$fg" "$status_prev_bg" "$text")
+  status_prev_bg="$bg"
+}

--- a/home-manager/scripts/tmux/status/network.sh
+++ b/home-manager/scripts/tmux/status/network.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+tmux_status_collect_network() {
+  default_iface="$(route -n get default 2>/dev/null | awk '/interface:/ { print $2; exit }' || true)"
+
+  wifi_active="no"
+  lan_active="no"
+  for iface in $(ifconfig -l 2>/dev/null); do
+    case "$iface" in
+      en0)
+        if ipconfig getifaddr "$iface" >/dev/null 2>&1; then
+          wifi_active="yes"
+        fi
+        ;;
+      en*)
+        if ipconfig getifaddr "$iface" >/dev/null 2>&1; then
+          lan_active="yes"
+        fi
+        ;;
+    esac
+  done
+
+  if [ "$wifi_active" = "yes" ] && [ "$lan_active" = "yes" ]; then
+    if [ "$default_iface" = "en0" ]; then
+      network_label="󰖩 wifi · 󰈀 lan"
+    else
+      network_label="󰈀 lan · 󰖩 wifi"
+    fi
+    network_color="#8ec07c"
+  elif [ "$lan_active" = "yes" ]; then
+    network_label="󰈀 lan"
+    network_color="#83a598"
+  elif [ "$wifi_active" = "yes" ]; then
+    network_label="󰖩 wifi"
+    network_color="#8ec07c"
+  else
+    network_label="󰖪 offline"
+    network_color="#928374"
+  fi
+
+  net="$(DEFAULT_IFACE="$default_iface" python3 -c "
+import os, subprocess, time
+
+iface=os.environ.get('DEFAULT_IFACE') or 'en0'
+cache=f'/tmp/tmux_net_cache_{iface}'
+def get_bytes():
+    out = subprocess.run(['netstat','-ib'], capture_output=True, text=True).stdout
+    for line in out.split('\n'):
+        if line.startswith(iface) and '<Link#' in line:
+            parts = line.split()
+            try: return int(parts[6]), int(parts[9]), time.time()
+            except: pass
+    return 0, 0, time.time()
+
+rx2, tx2, t2 = get_bytes()
+try:
+    with open(cache) as f:
+        parts = f.read().split()
+        rx1, tx1, t1 = int(parts[0]), int(parts[1]), float(parts[2])
+    dt = max(t2 - t1, 1)
+    rx_kb = max(rx2 - rx1, 0) / dt / 1024
+    tx_kb = max(tx2 - tx1, 0) / dt / 1024
+    def fmt(k):
+        return f'{k/1024:.1f}MiB/s' if k >= 1024 else f'{k:.0f}KiB/s'
+    result = f'↓{fmt(rx_kb)} ↑{fmt(tx_kb)}'
+except:
+    result = '...'
+with open(cache, 'w') as f:
+    f.write(f'{rx2} {tx2} {t2}')
+print(result)
+" 2>/dev/null || echo "n/a")"
+}

--- a/home-manager/scripts/tmux/status/status-right.sh
+++ b/home-manager/scripts/tmux/status/status-right.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$script_dir/lib.sh"
+source "$script_dir/network.sh"
+source "$script_dir/vpn.sh"
+source "$script_dir/aws.sh"
+source "$script_dir/system.sh"
+
+tmux_status_collect_network
+tmux_status_collect_vpn
+tmux_status_collect_aws
+tmux_status_collect_system
+
+status_output=""
+status_prev_bg="#1d2021"
+
+append_segment "#3c3836" "#83a598" "$net"
+append_segment "#504945" "$network_color" "$network_label"
+
+if [ -n "$vpn_label" ]; then
+  append_segment "#b8bb26" "#1d2021" "$vpn_label"
+fi
+
+append_segment "#3c3836" "$aws_color" "$aws_status"
+append_segment "#504945" "#83a598" "$k8s_status"
+append_segment "#3c3836" "#d5c4a1" "$nix_status"
+append_segment "#504945" "$load_color" "$load_status"
+append_segment "#3c3836" "#a89984" "󰋊 $disk"
+append_segment "#504945" "$cpu_color" " $cpu"
+append_segment "#3c3836" "#ebdbb2" " $mem"
+append_segment "#504945" "$battery_color" "$batt_icon $battery"
+append_segment "#3c3836" "#d5c4a1" "$datetime"
+append_segment "#bdae93" "#3c3836" "$(hostname -s)"
+
+printf '%s#[default]' "$status_output"

--- a/home-manager/scripts/tmux/status/system.sh
+++ b/home-manager/scripts/tmux/status/system.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+tmux_status_collect_system() {
+  disk="$(
+    df -h /System/Volumes/Data / 2>/dev/null \
+      | awk 'NR==2{print $5 " " $3 "/" $2; exit}' \
+      || echo "n/a"
+  )"
+  [ -n "$disk" ] || disk="n/a"
+
+  k8s_status="$(
+    if command -v kubectl >/dev/null 2>&1; then
+      context="$(kubectl config current-context 2>/dev/null || true)"
+      namespace="$(kubectl config view --minify --output 'jsonpath={..namespace}' 2>/dev/null || true)"
+      [ -n "$namespace" ] || namespace="default"
+      [ -n "$context" ] && printf '󱃾 %s/%s' "$context" "$namespace"
+    fi
+  )"
+
+  nix_generation="$(
+    readlink /nix/var/nix/profiles/system 2>/dev/null \
+      | sed -n 's/^system-\([0-9][0-9]*\)-link$/\1/p' \
+      || true
+  )"
+  nix_status=""
+  [ -n "$nix_generation" ] && nix_status=" $nix_generation"
+
+  load_avg="$(uptime 2>/dev/null | awk -F'load averages?: ' '{ print $2 }' | awk '{ gsub(",", "", $1); print $1; exit }' || true)"
+  load_status=""
+  load_color="#b8bb26"
+  if [ -n "$load_avg" ]; then
+    load_status="󰓅 $load_avg"
+    load_bucket="${load_avg%%.*}"
+    if [ "$load_bucket" -ge 8 ] 2>/dev/null; then
+      load_color="#fb4934"
+    elif [ "$load_bucket" -ge 4 ] 2>/dev/null; then
+      load_color="#fabd2f"
+    fi
+  fi
+
+  cpu="$(
+    top -l 1 2>/dev/null \
+      | awk -F'[:,%]' '/CPU usage/ { gsub(/^ +| +$/, "", $2); gsub(/^ +| +$/, "", $4); printf "%.0f%%", $2 + $4; exit }' \
+      || true
+  )"
+  [ -n "$cpu" ] || cpu="n/a"
+
+  mem="$(
+    vm_stat 2>/dev/null | awk '
+      /page size of/ { pageSize = $8 }
+      /Pages active/ { active = $3 }
+      /Pages inactive/ { inactive = $3 }
+      /Pages speculative/ { speculative = $3 }
+      /Pages wired down/ { wired = $4 }
+      END {
+        gsub(/\./, "", active);
+        gsub(/\./, "", inactive);
+        gsub(/\./, "", speculative);
+        gsub(/\./, "", wired);
+        used = (active + inactive + speculative + wired) * pageSize / 1024 / 1024 / 1024;
+        if (used > 0) {
+          printf "%.1fG", used;
+        }
+      }
+    ' \
+    || true
+  )"
+  [ -n "$mem" ] || mem="n/a"
+
+  battery="$(
+    pmset -g batt 2>/dev/null \
+      | awk -F';' '/%/ { gsub(/^ +| +$/, "", $1); sub(/^.*\t/, "", $1); print $1; exit }' \
+      || true
+  )"
+  [ -n "$battery" ] || battery="n/a"
+
+  battery_charging="$(
+    pmset -g batt 2>/dev/null \
+      | awk '/AC Power/ { ac=1 } /charged|charging/ { if (ac && !/dischar/) print "yes"; exit }' \
+      || true
+  )"
+
+  cpu_color="#b8bb26"
+  cpu_value="${cpu%%%}"
+  if [ "$cpu_value" != "$cpu" ] && [ "$cpu_value" -ge 80 ] 2>/dev/null; then
+    cpu_color="#fb4934"
+  elif [ "$cpu_value" != "$cpu" ] && [ "$cpu_value" -ge 50 ] 2>/dev/null; then
+    cpu_color="#fabd2f"
+  fi
+
+  battery_color="#b8bb26"
+  battery_value="${battery%%%}"
+  if [ "$battery_value" != "$battery" ] && [ "$battery_value" -le 20 ] 2>/dev/null; then
+    battery_color="#fb4934"
+  elif [ "$battery_value" != "$battery" ] && [ "$battery_value" -le 50 ] 2>/dev/null; then
+    battery_color="#fabd2f"
+  fi
+
+  if [ "$battery_charging" = "yes" ]; then
+    batt_icon="󰂄"
+  else
+    batt_icon="󰁹"
+  fi
+
+  datetime="$(date "+%d-%b-%Y %H:%M" | tr '[:lower:]' '[:upper:]')"
+}

--- a/home-manager/scripts/tmux/status/vpn.sh
+++ b/home-manager/scripts/tmux/status/vpn.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+tmux_status_collect_vpn() {
+  connected_vpns="$(scutil --nc list 2>/dev/null | awk '/\(Connected\)/' || true)"
+  vpn_label=""
+
+  aws_vpn_connected="no"
+  if [ "${DOTFILES_TMUX_SHOW_AWS_VPN:-no}" = "yes" ]; then
+    if printf '%s\n' "$connected_vpns" | grep -Eiq 'aws|amazon|client vpn|vortexa.*vpn|vortexa_.*_vpn'; then
+      aws_vpn_connected="yes"
+    elif ifconfig 2>/dev/null | awk '
+      /^utun[0-9]+:/ { in_utun=1; next }
+      /^[a-z0-9]+:/ { in_utun=0 }
+      in_utun && /inet 10\.250\./ { found=1 }
+      END { exit found ? 0 : 1 }
+    '; then
+      aws_vpn_connected="yes"
+    elif netstat -rn -f inet 2>/dev/null | awk '
+      $2 ~ /^10\.250\./ && $NF ~ /^utun[0-9]+$/ { found=1 }
+      END { exit found ? 0 : 1 }
+    '; then
+      aws_vpn_connected="yes"
+    fi
+  fi
+
+  if [ "$aws_vpn_connected" = "yes" ]; then
+    vpn_label="󰸏 VPN"
+  fi
+
+  if printf '%s\n' "$connected_vpns" | grep -Eiq 'tailscale'; then
+    vpn_label="${vpn_label:+$vpn_label · }󰖂 MESH"
+  fi
+
+  if [ -z "$vpn_label" ] && [ -n "$connected_vpns" ]; then
+    vpn_label="󰖂 VPN"
+  fi
+}

--- a/scripts/testing/check-nix-helper-semantics.sh
+++ b/scripts/testing/check-nix-helper-semantics.sh
@@ -76,6 +76,19 @@ check_eval_ok \
    then "ok"
    else throw "unexpected mkProfile override result"'
 
+check_eval_ok \
+  "Home Manager profile helper exposes profile booleans" \
+  'let
+     work = import ./home-manager/config/profile.nix { userConfig = { profile = "work"; }; };
+     personal = import ./home-manager/config/profile.nix { userConfig = { profile = "personal"; }; };
+   in
+   if work.isWork
+      && !work.isPersonal
+      && personal.isPersonal
+      && !personal.isWork
+   then "ok"
+   else throw "unexpected profile helper result"'
+
 if [[ "$HAS_FAILURES" -eq 0 ]]; then
   pass "local Nix helper semantics passed"
   exit 0

--- a/scripts/testing/check-tmux-status.sh
+++ b/scripts/testing/check-tmux-status.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Tmux Status Guardrail
+# Verifies the extracted tmux status modules stay syntactically valid and
+# produce a non-empty tmux status string.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+HAS_FAILURES=0
+
+pass() {
+  printf '[PASS] %s\n' "$1"
+}
+
+fail() {
+  printf '[FAIL] %s\n' "$1"
+  HAS_FAILURES=1
+}
+
+status_dir="home-manager/scripts/tmux/status"
+
+if [[ ! -d "$status_dir" ]]; then
+  fail "missing tmux status directory: $status_dir"
+else
+  failed_syntax=0
+  while IFS= read -r file; do
+    if ! bash -n "$file"; then
+      printf '[FAIL] bash syntax failed: %s\n' "$file"
+      failed_syntax=1
+    fi
+  done < <(find "$status_dir" -type f -name '*.sh' | sort)
+
+  if [[ "$failed_syntax" -eq 0 ]]; then
+    pass "tmux status shell syntax passed"
+  else
+    HAS_FAILURES=1
+  fi
+
+  output="$(DOTFILES_TMUX_SHOW_AWS_VPN=yes bash "$status_dir/status-right.sh" 2>/dev/null || true)"
+  if [[ -n "$output" && "$output" == *'#[default]'* ]]; then
+    pass "tmux status renders a non-empty tmux string"
+  else
+    fail "tmux status did not render expected tmux markup"
+  fi
+fi
+
+if [[ "$HAS_FAILURES" -eq 0 ]]; then
+  pass "tmux status guardrail passed"
+  exit 0
+fi
+
+fail "tmux status guardrail failed"
+exit 1

--- a/scripts/testing/onboarding-smoke.sh
+++ b/scripts/testing/onboarding-smoke.sh
@@ -197,6 +197,14 @@ check_hosts_no_emails() {
   fi
 }
 
+check_tmux_status() {
+  if ./scripts/testing/check-tmux-status.sh; then
+    pass "tmux status guardrail passed"
+  else
+    fail "tmux status guardrail failed"
+  fi
+}
+
 info "running onboarding smoke checks from $ROOT_DIR"
 check_command bash
 check_command rg
@@ -208,6 +216,7 @@ check_nix_flake
 check_script_references
 check_stale_patterns
 check_hosts_no_emails
+check_tmux_status
 
 if [[ "$HAS_FAILURES" -eq 0 ]]; then
   pass "onboarding smoke checks passed"


### PR DESCRIPTION
## Summary
- add architecture ownership docs and homelab runbooks
- split tmux status and dev-tool aliases into focused modules
- centralize profile/AWS helper behavior and add guardrails

## Verification
- nixfmt
- zsh -n home-manager/scripts/aws-sso.zsh
- ./scripts/testing/check-tmux-status.sh
- ./scripts/testing/check-nix-helper-semantics.sh
- nix flake check --no-build
- ./scripts/testing/onboarding-smoke.sh