### PR TITLE
feat: graphify integration, autoCompact, EU Bedrock model overrides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -193,6 +193,7 @@
   # Replaces manual theme configurations across applications
   stylix = {
     enable = true;
+    enableReleaseChecks = false; # Stylix release metadata currently lags nix-darwin.
 
     # Gruvbox Dark theme (matches your current manual configs)
     base16Scheme = "${pkgs.base16-schemes}/share/themes/gruvbox-dark-hard.yaml";

--- a/darwin/homebrew-packages/casks/apps.nix
+++ b/darwin/homebrew-packages/casks/apps.nix
@@ -18,4 +18,5 @@
   "vlc"
   "whatsapp"
   # "steam"
+#  "agentsview"
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -71,16 +71,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778427648,
-        "narHash": "sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE=",
+        "lastModified": 1779646357,
+        "narHash": "sha256-rnnAaESXxItX4D9xCMGvs3hfDBjbbTYht7OluRcvT8k=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "6f293daa9f9f5832e13b497976335e90509886d7",
+        "rev": "10a163ac127624caa80cc5cc5a705e97f3615b0e",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.11",
+        "ref": "5.1.14",
         "repo": "brew",
         "type": "github"
       }
@@ -92,11 +92,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1780795403,
+        "narHash": "sha256-AkWx4Zt9pQbD/f82Z8N57+d0HGLN/rV3gdMKJTpBPKs=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "6a771120d607dcccb279a27d227650e324815c35",
         "type": "github"
       },
       "original": {
@@ -182,11 +182,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780370888,
-        "narHash": "sha256-PRJj9RKTEf/sITycujP1c/BrvLJKMYXzcpwTsXNulXQ=",
+        "lastModified": 1780943742,
+        "narHash": "sha256-01bTMR9ZPG+uxPaZBeOwagg5uxIaFYs2/3YIrOX+bCA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a7a415883195ffbd4dabec8f098f201e6eaaadf8",
+        "rev": "df39142474950e42d5fc3bf2fef9d6c62abbe8d7",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1778851564,
-        "narHash": "sha256-p8wzcnpB2Iys+QzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE=",
+        "lastModified": 1780492467,
+        "narHash": "sha256-zMEJwtQPmsPPgPczFkyjWHgd1z0HagOPS2Wt2WDYLJY=",
         "owner": "zhaofengli-wip",
         "repo": "nix-homebrew",
-        "rev": "b3a87b4793205cc111f3c61e25e018ffac3b8039",
+        "rev": "562332f97de9f5ba51aa647d70462e88222b2988",
         "type": "github"
       },
       "original": {
@@ -215,11 +215,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780336545,
-        "narHash": "sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ=",
+        "lastModified": 1780747962,
+        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
+        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
         "type": "github"
       },
       "original": {
@@ -241,11 +241,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779766384,
-        "narHash": "sha256-P7Ohnlq8b8b2fU+Sgkrej7LBTM60LBTkHleLuYzmLmU=",
+        "lastModified": 1780281641,
+        "narHash": "sha256-M/+hUKoKbHXpV0xGVfELbN1Ds1aoe3pL5p5/t46YhVo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "57800b7ab648725ccd33551d01484ee14952ad3f",
+        "rev": "30f9ae2f04174de63ba8bcf3580ca90843b28a01",
         "type": "github"
       },
       "original": {
@@ -283,11 +283,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1780256506,
-        "narHash": "sha256-wEXN/OoZt9HfsKBL6694p2Y9xRlwfUbdn/M107U8fVU=",
+        "lastModified": 1780701809,
+        "narHash": "sha256-u7AUNs6U6eD1os4+ghbr1gH4QjPWzOdKvpeM+E+XRKM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "8ed48a41087feeb66372ff718021a9512fc552b3",
+        "rev": "3a02d9f73608641b28e08b26acb0b0b47c05f14b",
         "type": "github"
       },
       "original": {

--- a/home-manager/config/claude.nix
+++ b/home-manager/config/claude.nix
@@ -10,9 +10,64 @@
   effortLevel = "low";
 
   # EU geo inference endpoints keep the default model path GDPR-friendly.
+  # These map to env vars (ANTHROPIC_MODEL, ANTHROPIC_DEFAULT_HAIKU_MODEL,
+  # ANTHROPIC_DEFAULT_OPUS_MODEL) — runtime wiring for which model handles each role.
   models = {
     default = "eu.anthropic.claude-sonnet-4-6";
     fast = "eu.anthropic.claude-haiku-4-5-20251001-v1:0";
-    opus = "global.anthropic.claude-opus-4-6-v1";
+    opus = "eu.anthropic.claude-opus-4-8";
+  };
+
+  # Allowlist for the /model picker UI in Claude Code.
+  # Must use standard Claude model IDs (not Bedrock IDs) — picker won't recognize eu.* IDs.
+  # Family aliases — Claude Code resolves these against its internal model registry.
+  # Full version IDs (claude-opus-4-5) only work if CC knows them; aliases always work.
+  availableModels = [
+    "sonnet"
+    "opus"
+    "haiku"
+  ];
+
+  # Maps standard model IDs → EU Bedrock inference profile IDs.
+  # Picker shows standard names; runtime routes to EU endpoints for GDPR compliance.
+  # Opus 4.5 maps to latest eu opus (4-8) — Bedrock version suffix not recognized by picker.
+  modelOverrides = {
+    "claude-sonnet-4-6" = "eu.anthropic.claude-sonnet-4-6";
+    "claude-opus-4-5" = "eu.anthropic.claude-opus-4-8";
+    "claude-haiku-4-5" = "eu.anthropic.claude-haiku-4-5-20251001-v1:0";
+  };
+
+  # Plugins restored on every nix rebuild — survive settings.json resets.
+  enabledPlugins = {
+    "superpowers@claude-plugins-official" = true;
+    "frontend-design@claude-plugins-official" = true;
+    "context7@claude-plugins-official" = true;
+    "code-review@claude-plugins-official" = true;
+    "code-simplifier@claude-plugins-official" = true;
+    "skill-creator@claude-plugins-official" = true;
+    "claude-md-management@claude-plugins-official" = true;
+    "ralph-loop@claude-plugins-official" = true;
+    "security-guidance@claude-plugins-official" = true;
+    "claude-code-setup@claude-plugins-official" = true;
+    "pr-review-toolkit@claude-plugins-official" = true;
+    "codex@openai-codex" = true;
+    "caveman@caveman" = true;
+    "rust-analyzer-lsp@claude-plugins-official" = true;
+    "pyright-lsp@claude-plugins-official" = true;
+  };
+
+  extraKnownMarketplaces = {
+    openai-codex = {
+      source = {
+        source = "github";
+        repo = "openai/codex-plugin-cc";
+      };
+    };
+    caveman = {
+      source = {
+        source = "github";
+        repo = "JuliusBrussee/caveman";
+      };
+    };
   };
 }

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -189,6 +189,7 @@ in
     tmux.enable = true; # ENABLED: Native Stylix support
 
     # Disable unsupported or conflicting targets
+    gtk.enable = false; # DISABLED: Keep gtk.gtk4.theme explicitly unmanaged
     vim.enable = false; # DISABLED: Using Neovim instead
     firefox.enable = false; # DISABLED: Not our primary browser
   };

--- a/home-manager/modules/claude-code.nix
+++ b/home-manager/modules/claude-code.nix
@@ -53,16 +53,25 @@ let
       MAX_THINKING_TOKENS = claude.maxThinkingTokens;
 
       # Model selection - defaults use EU endpoints for GDPR compliance
-      # Sonnet: Balanced speed and capability (default)
+      # Primary model for agentic tasks (overridable via --model or /model)
       ANTHROPIC_MODEL = claude.models.default;
-      # Haiku: Fast responses, lower cost (for simple tasks)
-      ANTHROPIC_SMALL_FAST_MODEL = claude.models.fast;
-      # Opus: Most capable (for complex reasoning)
+      # Haiku-class model for background/fast operations
+      ANTHROPIC_DEFAULT_HAIKU_MODEL = claude.models.fast;
+      # Opus-class model for complex reasoning tasks
       ANTHROPIC_DEFAULT_OPUS_MODEL = claude.models.opus;
     };
 
     model = claude.model;
     effortLevel = claude.effortLevel;
+    autoCompactEnabled = true;
+    availableModels = claude.availableModels;
+    modelOverrides = claude.modelOverrides;
+
+    # Plugins managed by nix so they survive settings.json resets.
+    # Claude Code mutates this file when installing/removing plugins.
+    enabledPlugins = claude.enabledPlugins;
+    extraKnownMarketplaces = claude.extraKnownMarketplaces;
+
     statusLine = {
       type = "command";
       command = "bash \"${statuslinePath}\"";


### PR DESCRIPTION
## Summary

- Add `autoCompactEnabled: true` to Claude Code settings
- Add `availableModels` + `modelOverrides` for EU Bedrock geo routing via `/model` picker
- Add `enabledPlugins` + `extraKnownMarketplaces` — survive `settings.json` resets on rebuild
- Replace deprecated `ANTHROPIC_SMALL_FAST_MODEL` → `ANTHROPIC_DEFAULT_HAIKU_MODEL`
- Add `CLAUDE.md` with graphify knowledge graph integration (auto-query on codebase questions)
- Stylix: set `enableReleaseChecks = false`, disable `gtk`
- `flake.lock` bump (brew 5.1.14, nix-darwin, home-manager, stylix, nixpkgs)

## Test plan

- [ ] `rm -f ~/.claude/settings.json && darwin-rebuild switch` → verify `settings.json` has `autoCompactEnabled`, `availableModels`, `modelOverrides`, `enabledPlugins`
- [ ] `/model` picker in Claude Code shows sonnet/opus/haiku
- [ ] Plugins present after settings reset