### PR TITLE
fix: uncomment onboarding-checks workflow

### DIFF
--- a/.github/workflows/onboarding-checks.yml
+++ b/.github/workflows/onboarding-checks.yml
@@ -1,64 +1,64 @@
-#name: Onboarding Checks
-#
-#on:
-#  pull_request:
-#    paths:
-#      - '**/*.nix'
-#      - 'flake.nix'
-#      - 'flake.lock'
-#      - '.github/workflows/onboarding-checks.yml'
-#      - 'scripts/testing/**'
-#      - 'scripts/install/**'
-#      - 'scripts/setup/**'
-#      - 'setup.sh'
-#  push:
-#    branches:
-#      - main
-#    paths:
-#      - '**/*.nix'
-#      - 'flake.nix'
-#      - 'flake.lock'
-#      - '.github/workflows/onboarding-checks.yml'
-#      - 'scripts/testing/**'
-#      - 'scripts/install/**'
-#      - 'scripts/setup/**'
-#      - 'setup.sh'
-#
-#jobs:
-#  onboarding:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v4
-#
-#      - name: Install Nix
-#        uses: DeterminateSystems/nix-installer-action@v17
-#
-#      - name: Install shell tools
-#        run: |
-#          sudo apt-get update
-#          sudo apt-get install -y shellcheck ripgrep
-#
-#      - name: Create CI hosts.nix
-#        run: |
-#          cat > ./hosts.nix <<'EOF'
-#          {
-#            common = {
-#              username = "runner";
-#              fullName = "CI Runner";
-#              githubUsername = "ci";
-#              signingKey = "";
-#            };
-#            hosts = {
-#              ci = {
-#                hostname = "ci-mac";
-#                profile = "work";
-#              };
-#            };
-#          }
-#          EOF
-#
-#      - name: Run onboarding smoke checks
-#        run: |
-#          chmod +x ./scripts/testing/onboarding-smoke.sh
-#          ./scripts/testing/onboarding-smoke.sh --strict-shellcheck
+name: Onboarding Checks
+
+on:
+  pull_request:
+    paths:
+      - '**/*.nix'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/onboarding-checks.yml'
+      - 'scripts/testing/**'
+      - 'scripts/install/**'
+      - 'scripts/setup/**'
+      - 'setup.sh'
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.nix'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/onboarding-checks.yml'
+      - 'scripts/testing/**'
+      - 'scripts/install/**'
+      - 'scripts/setup/**'
+      - 'setup.sh'
+
+jobs:
+  onboarding:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v17
+
+      - name: Install shell tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck ripgrep
+
+      - name: Create CI hosts.nix
+        run: |
+          cat > ./hosts.nix <<'EOF'
+          {
+            common = {
+              username = "runner";
+              fullName = "CI Runner";
+              githubUsername = "ci";
+              signingKey = "";
+            };
+            hosts = {
+              ci = {
+                hostname = "ci-mac";
+                profile = "work";
+              };
+            };
+          }
+          EOF
+
+      - name: Run onboarding smoke checks
+        run: |
+          chmod +x ./scripts/testing/onboarding-smoke.sh
+          ./scripts/testing/onboarding-smoke.sh --strict-shellcheck


### PR DESCRIPTION
Workflow was fully commented out — GitHub treated it as invalid, causing CI failure. Uncommented to re-enable checks.