### PR TITLE
feat: declarative skills, plugins, and package migration to Nix

### DIFF
--- a/darwin/homebrew-packages/brews/core.nix
+++ b/darwin/homebrew-packages/brews/core.nix
@@ -3,8 +3,7 @@
 # These are intentionally kept in Homebrew because they integrate with macOS,
 # Homebrew itself, or globally expected system behavior.
 [
-  "coreutils"
-  "gnu-getopt"
-  "gnupg"
-  "mas"
+  "coreutils" # GNU core utils expected by macOS shell scripts
+  "gnu-getopt" # GNU getopt used in PATH for scripts
+  "mas" # Mac App Store CLI
 ]

--- a/darwin/homebrew-packages/brews/development.nix
+++ b/darwin/homebrew-packages/brews/development.nix
@@ -3,9 +3,6 @@
 # Prefer Home Manager for user-level CLI tools. Keep tools here only when their
 # Homebrew installation is the deliberate global source of truth.
 [
-  "herdr"
-  "infisical"
-  "kubevela"
-  "neovim"
-  "yamlresume"
+  "herdr" # nixpkgs build broken on aarch64-darwin (DarwinSdkNotFound in Zig/Ghostty dep)
+  "yamlresume" # Not in nixpkgs
 ]

--- a/darwin/homebrew-packages/brews/toolchains.nix
+++ b/darwin/homebrew-packages/brews/toolchains.nix
@@ -2,14 +2,4 @@
 #
 # These are shared by IDEs, editors, and project tooling. Before moving one to
 # Home Manager, check docs/guides/toolchain-ownership.md.
-[
-  "uv"
-  "poetry"
-  "python@3.12"
-  "cmake"
-  "maven"
-  "pkg-config"
-  "go"
-  "node"
-  "kafka"
-]
+[ ]

--- a/docs/skills-management.md
+++ b/docs/skills-management.md
@@ -1,0 +1,164 @@
+# Claude Code Skills Management
+
+Research notes + tradeoff analysis for bringing skills under dotfile/Nix management.
+
+---
+
+## Current State (Satyasheel)
+
+```
+~/.agents/skills/<skill>/    ← actual files, NOT git-tracked
+~/.claude/skills/<skill>/    ← symlinks into ~/.agents/skills/
+```
+
+Skills arrived via an installer (likely `ce-setup` or `setup-matt-pocock-skills` skill).
+Dates in `~/.agents/skills/` cluster around 2026-05-26 and 2026-05-27 — two install runs.
+
+**Sources visible from skill content:**
+- `ce-*` prefix → Claude Code / Anthropic superpowers catalog
+- `animejs`, `css-animations`, `gsap`, `lottie`, `three`, `typegpu`, `waapi`, `hyperframes*`, `remotion-*` → animation/frontend cluster (likely one publisher)
+- `grill-me`, `grill-with-docs`, `tdd`, `to-issues`, `to-prd`, `triage`, `diagnose`, `improve-codebase-architecture`, `prototype`, `coding-tutor` → Matt Pocock skills catalog
+
+**Problem:** Fresh Nix rebuild = skills gone. No declarative source of truth.
+
+---
+
+## Reference: Edmund Miller's Approach
+
+Repo: https://github.com/edmundmiller/dotfiles
+
+### Architecture
+
+```
+dotfiles/
+├── flake.nix                    ← imports skills/ as child flake
+├── flake.lock                   ← locks skills-catalog flake input too
+└── skills/
+    ├── flake.nix                ← declares upstream skill repos as inputs
+    ├── flake.lock               ← independent lock for skill inputs
+    ├── catalog/<name>/SKILL.md  ← locally-authored skills
+    └── conditional/<name>/      ← wrapped upstream skills
+```
+
+### Upstream repos declared in `skills/flake.nix`
+
+Each uses `flake = false` — content-addressed, not evaluated as a flake:
+
+```nix
+mattpocock-skills = { url = "github:mattpocock/skills"; flake = false; };
+mitsuhiko-skills  = { url = "github:mitsuhiko/agents";  flake = false; };
+bholmesdev        = { url = "github:bholmesdev/...";    flake = false; };
+gitbutler         = { url = "github:gitbutler-app/..."; flake = false; };
+herdr             = { url = "github:acpxio/herdr";      flake = false; };
+acpx              = { url = "github:acpxio/acpx";       flake = false; };
+# + ~15 more
+```
+
+### Deployment via Home Manager
+
+- Module: `programs.agent-skills` from `inputs.skills-catalog.homeManagerModules.default`
+- Skills are **copied** (not symlinked) so agents can mutate them at runtime
+- 6 deployment targets: `~/.claude/skills`, `~/.agents/skills`, `~/.pi/agent/skills`,
+  `~/.codex/skills`, `~/.config/opencode/skills`, `~/.hermes/skills`
+- Conditional: skill only deployed if parent module enabled (`claude.enable`, `git.enable`, etc.)
+- Skills can be augmented with a `transform` block to append custom content per-agent
+
+### Lock sync requirement
+
+Two lock files must stay in sync. Pre-commit hook enforces:
+
+```
+skills/flake.lock  ← skill input pins
+flake.lock         ← includes skills-catalog entry
+
+# Update flow:
+cd skills && nix flake lock --update-input mattpocock-skills
+cd ..      && nix flake update skills-catalog
+```
+
+### Update workflow
+
+```bash
+cd skills
+nix flake lock --update-input <source-name>   # update one skill source
+cd ..
+nix flake update skills-catalog               # propagate to parent
+darwin-rebuild switch                         # deploy
+```
+
+---
+
+## Tradeoff Analysis
+
+### Current (manual install, no tracking)
+
+| | |
+|---|---|
+| **Pro** | Zero setup. Skills just work. |
+| **Pro** | Always latest — installer pulled current at time of run. |
+| **Con** | Not reproducible. Fresh machine = manually re-run installer. |
+| **Con** | No record of which skills or versions are installed. |
+| **Con** | Skills can drift between machines silently. |
+| **Con** | Can't roll back a bad skill update. |
+
+### Edmund's approach (child flake + HM module)
+
+| | |
+|---|---|
+| **Pro** | Fully reproducible — `darwin-rebuild switch` restores everything. |
+| **Pro** | Hash-pinned — exact version known, rollback possible via `git revert`. |
+| **Pro** | Conditional — only deploy what's relevant to enabled modules. |
+| **Pro** | Works for all 6 agent targets in one declaration. |
+| **Con** | Significant complexity: child flake, parent lock sync, HM module. |
+| **Con** | You own the lock bump — upstream releases don't auto-arrive. |
+| **Con** | Need to find every upstream repo URL (some skills' origin is unknown). |
+| **Con** | `flake = false` inputs add to `nix flake update` time. |
+
+### Middle path (simpler Nix, no child flake)
+
+Declare skill repos directly as inputs in main `flake.nix` with `flake = false`.
+Write a small HM activation script that `cp -r` them into place.
+No separate child flake, no HM module dependency.
+
+| | |
+|---|---|
+| **Pro** | Reproducible and version-pinned. |
+| **Pro** | Much simpler than Edmund's full architecture. |
+| **Pro** | Fits your existing `home-manager/modules/claude-code.nix` pattern. |
+| **Con** | No conditional deployment logic (can add later if needed). |
+| **Con** | Main `flake.lock` grows with 20+ skill input entries. |
+| **Con** | Still need all upstream repo URLs. |
+
+---
+
+## Open Questions Before Implementing
+
+1. **What upstream repo did `ce-*` skills come from?**
+   The `ce-` prefix suggests Anthropic/Claude Code official skills catalog.
+   Need URL — possibly `github:anthropics/claude-code-skills` or similar.
+
+2. **What shipped `animejs`, `gsap`, `hyperframes*`, etc.?**
+   Animation-heavy cluster with consistent style. Likely one publisher repo.
+
+3. **Are any skills locally authored (not from upstream)?**
+   Check if any `SKILL.md` files look hand-written vs. published.
+   Local skills → store directly in dotfile under `home-manager/skills/catalog/`.
+
+4. **Acceptable complexity budget?**
+   Edmund's approach is powerful but ~200 lines of Nix across 3 files.
+   Middle path achieves 80% of the value in ~30 lines.
+
+---
+
+## Recommended Next Step
+
+Before writing any Nix:
+
+```bash
+# Try to identify skill origins
+cat ~/.agents/skills/animejs/SKILL.md | head -10
+cat ~/.agents/skills/ce-brainstorm/SKILL.md | head -5
+# Look for author/source metadata in skill frontmatter
+```
+
+Then: find the upstream repos, decide complexity budget, implement.

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "agent-extras": {
+      "inputs": {
+        "caveman-skill": "caveman-skill",
+        "claude-plugins-official": "claude-plugins-official",
+        "codex-plugin-cc": "codex-plugin-cc",
+        "compound-engineering": "compound-engineering",
+        "everyskill": "everyskill",
+        "hyperframes-skills": "hyperframes-skills",
+        "mattpocock-skills": "mattpocock-skills"
+      },
+      "locked": {
+        "path": "./home-manager/agent-extras",
+        "type": "path"
+      },
+      "original": {
+        "path": "./home-manager/agent-extras",
+        "type": "path"
+      },
+      "parent": []
+    },
     "base16": {
       "inputs": {
         "fromYaml": "fromYaml"
@@ -85,6 +105,70 @@
         "type": "github"
       }
     },
+    "caveman-skill": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781272264,
+        "narHash": "sha256-FbmfhFaPs/SnSZdfNdErdIUHXt1FfBzErpPpLy8kdIc=",
+        "owner": "JuliusBrussee",
+        "repo": "caveman",
+        "rev": "25d22f864ad68cc447a4cb93aefde918aa4aec9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "JuliusBrussee",
+        "repo": "caveman",
+        "type": "github"
+      }
+    },
+    "claude-plugins-official": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782583500,
+        "narHash": "sha256-fLyiL/gk46vdu/3wkTaBhNzuPEAnMQNRS8FZvtr724k=",
+        "owner": "anthropics",
+        "repo": "claude-plugins-official",
+        "rev": "30a213f9b39e3c40b0073bb5b41081da9f2b6634",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anthropics",
+        "repo": "claude-plugins-official",
+        "type": "github"
+      }
+    },
+    "codex-plugin-cc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782236175,
+        "narHash": "sha256-KJNJyAYVBsA6On/mrx9GSSQmjrwCHfQZAr+c3BZYUc0=",
+        "owner": "openai",
+        "repo": "codex-plugin-cc",
+        "rev": "80c31f99570876c3ef40327838b0a2ca1ae2cd9c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "openai",
+        "repo": "codex-plugin-cc",
+        "type": "github"
+      }
+    },
+    "compound-engineering": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782632880,
+        "narHash": "sha256-FNqM8T37Alg480zom6Kgu0LqYNdv6CsKHWbXv3o4CGU=",
+        "owner": "EveryInc",
+        "repo": "compound-engineering-plugin",
+        "rev": "afc5e010e69a135e726ae9713781db5af11203cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EveryInc",
+        "repo": "compound-engineering-plugin",
+        "type": "github"
+      }
+    },
     "darwin": {
       "inputs": {
         "nixpkgs": [
@@ -102,6 +186,22 @@
       "original": {
         "owner": "lnl7",
         "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "everyskill": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782327394,
+        "narHash": "sha256-/VHlVSiKAeaN5JjpMHOqH3z9bzUP7dXQ0VDhv6fSro0=",
+        "owner": "EveryInc",
+        "repo": "everyskill",
+        "rev": "e918150a8badf09c6de1550eecd181591685bf0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EveryInc",
+        "repo": "everyskill",
         "type": "github"
       }
     },
@@ -195,6 +295,38 @@
         "type": "github"
       }
     },
+    "hyperframes-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782582898,
+        "narHash": "sha256-pf9c0unmnXKwVTpE3TSr+KFBhudbEeKyRLWcm3KeCgc=",
+        "owner": "heygen-com",
+        "repo": "hyperframes",
+        "rev": "3351fb1a6d7f0202d07db9bf9ad335fd0d1ec344",
+        "type": "github"
+      },
+      "original": {
+        "owner": "heygen-com",
+        "repo": "hyperframes",
+        "type": "github"
+      }
+    },
+    "mattpocock-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782388103,
+        "narHash": "sha256-efsb/AXAmEvcjoknbExBeEHFB28o2c2Nk8muWwNNQFQ=",
+        "owner": "mattpocock",
+        "repo": "skills",
+        "rev": "5d78bd0903420f97c791f834201e550c765699f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mattpocock",
+        "repo": "skills",
+        "type": "github"
+      }
+    },
     "nix-homebrew": {
       "inputs": {
         "brew-src": "brew-src"
@@ -256,6 +388,7 @@
     },
     "root": {
       "inputs": {
+        "agent-extras": "agent-extras",
         "darwin": "darwin",
         "home-manager": "home-manager",
         "nix-homebrew": "nix-homebrew",

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # Agent skills and plugin marketplaces — pinned via child flake; update with:
+    #   cd home-manager/agent-extras && nix flake update
+    #   nix flake update agent-extras
+    agent-extras.url = "path:./home-manager/agent-extras";
+
   };
 
   outputs =
@@ -73,6 +78,7 @@
       home-manager,
       nix-homebrew,
       stylix,
+      agent-extras,
       ...
     }:
     let
@@ -109,6 +115,15 @@
                 # User-specific Arguments
                 extraSpecialArgs = {
                   userConfig = validatedConfig;
+                  inherit (agent-extras.inputs)
+                    compound-engineering
+                    hyperframes-skills
+                    mattpocock-skills
+                    caveman-skill
+                    everyskill
+                    claude-plugins-official
+                    codex-plugin-cc
+                    ;
                   inherit (validatedConfig)
                     username
                     fullName

--- a/home-manager/agent-extras/flake.lock
+++ b/home-manager/agent-extras/flake.lock
@@ -1,0 +1,129 @@
+{
+  "nodes": {
+    "caveman-skill": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781272264,
+        "narHash": "sha256-FbmfhFaPs/SnSZdfNdErdIUHXt1FfBzErpPpLy8kdIc=",
+        "owner": "JuliusBrussee",
+        "repo": "caveman",
+        "rev": "25d22f864ad68cc447a4cb93aefde918aa4aec9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "JuliusBrussee",
+        "repo": "caveman",
+        "type": "github"
+      }
+    },
+    "claude-plugins-official": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782583500,
+        "narHash": "sha256-fLyiL/gk46vdu/3wkTaBhNzuPEAnMQNRS8FZvtr724k=",
+        "owner": "anthropics",
+        "repo": "claude-plugins-official",
+        "rev": "30a213f9b39e3c40b0073bb5b41081da9f2b6634",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anthropics",
+        "repo": "claude-plugins-official",
+        "type": "github"
+      }
+    },
+    "codex-plugin-cc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782236175,
+        "narHash": "sha256-KJNJyAYVBsA6On/mrx9GSSQmjrwCHfQZAr+c3BZYUc0=",
+        "owner": "openai",
+        "repo": "codex-plugin-cc",
+        "rev": "80c31f99570876c3ef40327838b0a2ca1ae2cd9c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "openai",
+        "repo": "codex-plugin-cc",
+        "type": "github"
+      }
+    },
+    "compound-engineering": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782632880,
+        "narHash": "sha256-FNqM8T37Alg480zom6Kgu0LqYNdv6CsKHWbXv3o4CGU=",
+        "owner": "EveryInc",
+        "repo": "compound-engineering-plugin",
+        "rev": "afc5e010e69a135e726ae9713781db5af11203cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EveryInc",
+        "repo": "compound-engineering-plugin",
+        "type": "github"
+      }
+    },
+    "everyskill": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782327394,
+        "narHash": "sha256-/VHlVSiKAeaN5JjpMHOqH3z9bzUP7dXQ0VDhv6fSro0=",
+        "owner": "EveryInc",
+        "repo": "everyskill",
+        "rev": "e918150a8badf09c6de1550eecd181591685bf0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EveryInc",
+        "repo": "everyskill",
+        "type": "github"
+      }
+    },
+    "hyperframes-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782582898,
+        "narHash": "sha256-pf9c0unmnXKwVTpE3TSr+KFBhudbEeKyRLWcm3KeCgc=",
+        "owner": "heygen-com",
+        "repo": "hyperframes",
+        "rev": "3351fb1a6d7f0202d07db9bf9ad335fd0d1ec344",
+        "type": "github"
+      },
+      "original": {
+        "owner": "heygen-com",
+        "repo": "hyperframes",
+        "type": "github"
+      }
+    },
+    "mattpocock-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782388103,
+        "narHash": "sha256-efsb/AXAmEvcjoknbExBeEHFB28o2c2Nk8muWwNNQFQ=",
+        "owner": "mattpocock",
+        "repo": "skills",
+        "rev": "5d78bd0903420f97c791f834201e550c765699f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mattpocock",
+        "repo": "skills",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "caveman-skill": "caveman-skill",
+        "claude-plugins-official": "claude-plugins-official",
+        "codex-plugin-cc": "codex-plugin-cc",
+        "compound-engineering": "compound-engineering",
+        "everyskill": "everyskill",
+        "hyperframes-skills": "hyperframes-skills",
+        "mattpocock-skills": "mattpocock-skills"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/home-manager/agent-extras/flake.nix
+++ b/home-manager/agent-extras/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "Pinned agent skill and plugin marketplace sources";
+
+  inputs = {
+    # Skills
+    compound-engineering = {
+      url = "github:EveryInc/compound-engineering-plugin";
+      flake = false;
+    };
+    hyperframes-skills = {
+      url = "github:heygen-com/hyperframes";
+      flake = false;
+    };
+    mattpocock-skills = {
+      url = "github:mattpocock/skills";
+      flake = false;
+    };
+    caveman-skill = {
+      url = "github:JuliusBrussee/caveman";
+      flake = false;
+    };
+    everyskill = {
+      url = "github:EveryInc/everyskill";
+      flake = false;
+    };
+
+    # Plugin marketplaces
+    claude-plugins-official = {
+      url = "github:anthropics/claude-plugins-official";
+      flake = false;
+    };
+    codex-plugin-cc = {
+      url = "github:openai/codex-plugin-cc";
+      flake = false;
+    };
+  };
+
+  outputs = _: { };
+}

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -94,6 +94,8 @@ in
     ./modules/github.nix
     ./modules/gpg.nix
     ./modules/claude-code.nix
+    ./modules/skills.nix
+    ./modules/plugins.nix
     ./modules/opencode.nix
     ./modules/pi.nix
     ./modules/antigravity.nix

--- a/home-manager/modules/antigravity.nix
+++ b/home-manager/modules/antigravity.nix
@@ -13,6 +13,8 @@ let
   statuslinePath = "${config.home.homeDirectory}/.gemini/antigravity-cli/statusline.sh";
 in
 {
+  programs.antigravity-cli.enable = true;
+
   home.file.".gemini/antigravity-cli/statusline.sh" = {
     source = ./antigravity/statusline.sh;
     executable = true;

--- a/home-manager/modules/claude-code.nix
+++ b/home-manager/modules/claude-code.nix
@@ -96,6 +96,8 @@ in
   # Activation merges only Nix-owned Bedrock defaults into that live file.
   # Location: ~/.claude/settings.default.json
   # Docs: https://docs.anthropic.com/claude-code/configuration
+  programs.claude-code.enable = true;
+
   home.file.".claude/settings.default.json".text = settings;
   home.activation.ensureClaudeMutableSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     mkdir -p "$HOME/.claude"

--- a/home-manager/modules/codex.nix
+++ b/home-manager/modules/codex.nix
@@ -16,6 +16,8 @@ let
   codexConfig = "${config.home.homeDirectory}/.codex/config.toml";
 in
 {
+  programs.codex.enable = true;
+
   home.activation.configureCodexStatusline = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     mkdir -p "$(dirname "${codexConfig}")"
     if [ ! -s "${codexConfig}" ]; then

--- a/home-manager/modules/git.nix
+++ b/home-manager/modules/git.nix
@@ -91,16 +91,60 @@ in
         { }
     );
 
-    # Global Ignores
-    # Files to ignore in all repositories
     ignores = [
-      ".DS_Store" # macOS metadata
-      "*.swp" # Vim swap files
-      ".env" # Environment variables
-      ".direnv" # Direnv cache
-      "node_modules" # Node.js dependencies
-      ".vscode" # VS Code settings
-      ".idea" # IntelliJ settings
+      # macOS
+      ".DS_Store"
+      ".AppleDouble"
+      ".LSOverride"
+
+      # Editors
+      "*.swp"
+      "*.swo"
+      "*~"
+      ".vscode/"
+      ".idea/"
+      "*.iml"
+
+      # Env / secrets
+      ".env"
+      ".env.local"
+      ".env.*.local"
+
+      # Direnv
+      ".direnv/"
+      ".envrc.local"
+
+      # Node
+      "node_modules/"
+      ".npm"
+      ".pnpm-store/"
+
+      # Python
+      "__pycache__/"
+      "*.pyc"
+      "*.pyo"
+      ".venv/"
+      ".uv/"
+
+      # Nix
+      "result"
+      "result-*"
+
+      # Build artefacts
+      "dist/"
+      "build/"
+      "target/"
+      "*.o"
+      "*.a"
+
+      # Logs
+      "*.log"
+      "npm-debug.log*"
+
+      # Misc
+      ".cache/"
+      "*.bak"
+      "*.tmp"
     ];
   };
 

--- a/home-manager/modules/opencode.nix
+++ b/home-manager/modules/opencode.nix
@@ -16,6 +16,8 @@ let
   opencodeConfig = "${config.home.homeDirectory}/.config/opencode/opencode.json";
 in
 {
+  programs.opencode.enable = true;
+
   home.activation.configureOpenCodeLMStudio = lib.hm.dag.entryAfter [ "installCodingAgents" ] ''
     if [ ! -x "${opencodeBin}" ] || [ ! -d "/Applications/LM Studio.app" ]; then
       echo "OpenCode/LM Studio not installed; skipping OpenCode LM Studio config."

--- a/home-manager/modules/packages/cloud.nix
+++ b/home-manager/modules/packages/cloud.nix
@@ -14,5 +14,7 @@
     opentofu # OpenTofu infrastructure as code CLI
     terraform-docs # Generate docs from Terraform/OpenTofu modules
     tflint # Terraform/OpenTofu linter
+    infisical # Secrets management CLI
+    kubevela # KubeVela application platform CLI
   ];
 }

--- a/home-manager/modules/packages/development.nix
+++ b/home-manager/modules/packages/development.nix
@@ -7,11 +7,6 @@
 
 {
   home.packages = with pkgs; [
-    codex # OpenAI Codex CLI
-    claude-code # Claude Code CLI; configuration remains in modules/claude-code.nix
-    antigravity-cli # Antigravity CLI; statusline configuration remains in modules/antigravity.nix
-    opencode # OpenCode CLI; LM Studio configuration remains in modules/opencode.nix
-    pi-coding-agent # Pi Coding Agent CLI; local model configuration remains in modules/pi.nix
     httpie # Modern HTTP client
     shellcheck # Shell script linting
     git-extras # Additional Git commands and utilities

--- a/home-manager/modules/packages/languages.nix
+++ b/home-manager/modules/packages/languages.nix
@@ -13,15 +13,40 @@ in
 
 {
   home.packages = with pkgs; [
+    # Python
+    python312 # System Python (project versions managed by uv)
+    uv # Project deps + Python version management
+    poetry # Alternative Python project manager
+
+    # Kotlin
     kotlin-language-server # Kotlin LSP
+
+    # Python LSP
     pyright # Python LSP (type checking + intelligence)
     pyright-lsp # Compatibility command for tools expecting pyright-lsp
+
+    # TypeScript/JavaScript
     typescript-language-server # TypeScript/JavaScript LSP
     typescript # TypeScript compiler (required by ts-ls)
+
+    # Rust
     rust-analyzer # Rust LSP for code intelligence
     rustc # Rust compiler
     cargo # Rust package manager and build tool
     rustfmt # Rust code formatter
     clippy # Rust linter
+
+    # Go
+    go # Go compiler and toolchain
+
+    # JavaScript/Node
+    nodejs # Node.js runtime
+    bun # Fast JS runtime, bundler, package manager
+
+    # Build tools
+    cmake # Cross-platform build system
+    maven # Java/JVM build tool
+    pkg-config # Library metadata tool
+    apacheKafka # Kafka CLI tools
   ];
 }

--- a/home-manager/modules/pi.nix
+++ b/home-manager/modules/pi.nix
@@ -10,6 +10,8 @@ let
   json = pkgs.formats.json { };
 in
 {
+  programs.pi-coding-agent.enable = true;
+
   home.file.".pi/agent/models.json".source = json.generate "pi-models.json" {
     providers = {
       lmstudio = {

--- a/home-manager/modules/plugins.nix
+++ b/home-manager/modules/plugins.nix
@@ -1,0 +1,39 @@
+# home-manager/modules/plugins.nix
+#
+# Claude Code plugin configuration.
+#
+# Uses programs.claude-code.plugins (--plugin-dir wrapper flag) so every
+# listed plugin is active on every session without manual /install.
+#
+# Update pins:
+#   cd home-manager/agent-extras && nix flake update claude-plugins-official codex-plugin-cc
+#   nix flake update agent-extras
+{ claude-plugins-official, codex-plugin-cc, caveman-skill, ... }:
+let
+  official = claude-plugins-official;
+  codex = codex-plugin-cc;
+  caveman = caveman-skill;
+in
+{
+  programs.claude-code.plugins = [
+    # anthropics/claude-plugins-official
+    "${official}/plugins/claude-code-setup"
+    "${official}/plugins/claude-md-management"
+    "${official}/plugins/code-review"
+    "${official}/plugins/code-simplifier"
+    "${official}/plugins/frontend-design"
+    "${official}/plugins/pr-review-toolkit"
+    "${official}/plugins/pyright-lsp"
+    "${official}/plugins/ralph-loop"
+    "${official}/plugins/rust-analyzer-lsp"
+    "${official}/plugins/security-guidance"
+    "${official}/plugins/skill-creator"
+    "${official}/external_plugins/context7"
+
+    # openai/codex-plugin-cc
+    "${codex}/plugins/codex"
+
+    # JuliusBrussee/caveman (reuses skill input)
+    "${caveman}/plugins/caveman"
+  ];
+}

--- a/home-manager/modules/skills.nix
+++ b/home-manager/modules/skills.nix
@@ -1,0 +1,74 @@
+{
+  compound-engineering,
+  hyperframes-skills,
+  mattpocock-skills,
+  caveman-skill,
+  everyskill,
+  ...
+}:
+let
+  ce = compound-engineering;
+  hf = hyperframes-skills;
+  mp = mattpocock-skills;
+
+  sharedSkills = {
+    # compound-engineering
+    ce-brainstorm = "${ce}/skills/ce-brainstorm";
+    ce-code-review = "${ce}/skills/ce-code-review";
+    ce-commit = "${ce}/skills/ce-commit";
+    ce-commit-push-pr = "${ce}/skills/ce-commit-push-pr";
+    ce-compound = "${ce}/skills/ce-compound";
+    ce-compound-refresh = "${ce}/skills/ce-compound-refresh";
+    ce-debug = "${ce}/skills/ce-debug";
+    ce-doc-review = "${ce}/skills/ce-doc-review";
+    ce-dogfood-beta = "${ce}/skills/ce-dogfood-beta";
+    ce-ideate = "${ce}/skills/ce-ideate";
+    ce-optimize = "${ce}/skills/ce-optimize";
+    ce-plan = "${ce}/skills/ce-plan";
+    ce-proof = "${ce}/skills/ce-proof";
+    ce-resolve-pr-feedback = "${ce}/skills/ce-resolve-pr-feedback";
+    ce-riffrec-feedback-analysis = "${ce}/skills/ce-riffrec-feedback-analysis";
+    ce-setup = "${ce}/skills/ce-setup";
+    ce-simplify-code = "${ce}/skills/ce-simplify-code";
+    ce-strategy = "${ce}/skills/ce-strategy";
+    ce-test-browser = "${ce}/skills/ce-test-browser";
+    ce-test-xcode = "${ce}/skills/ce-test-xcode";
+    ce-work = "${ce}/skills/ce-work";
+    ce-worktree = "${ce}/skills/ce-worktree";
+    lfg = "${ce}/skills/lfg";
+
+    # hyperframes
+    hyperframes = "${hf}/skills/hyperframes";
+    hyperframes-cli = "${hf}/skills/hyperframes-cli";
+    hyperframes-media = "${hf}/skills/hyperframes-media";
+    hyperframes-registry = "${hf}/skills/hyperframes-registry";
+    animejs = "${hf}/skills/hyperframes-animation";
+    remotion-to-hyperframes = "${hf}/skills/remotion-to-hyperframes";
+
+    # mattpocock engineering
+    grill-with-docs = "${mp}/skills/engineering/grill-with-docs";
+    improve-codebase-architecture = "${mp}/skills/engineering/improve-codebase-architecture";
+    prototype = "${mp}/skills/engineering/prototype";
+    setup-matt-pocock-skills = "${mp}/skills/engineering/setup-matt-pocock-skills";
+    tdd = "${mp}/skills/engineering/tdd";
+    to-issues = "${mp}/skills/engineering/to-issues";
+    to-prd = "${mp}/skills/engineering/to-prd";
+    triage = "${mp}/skills/engineering/triage";
+
+    # mattpocock productivity
+    grill-me = "${mp}/skills/productivity/grill-me";
+    handoff = "${mp}/skills/productivity/handoff";
+
+    # caveman
+    caveman = "${caveman-skill}/skills/caveman";
+
+    # everyskill
+    coding-tutor = "${everyskill}/skills/coding-tutor";
+  };
+in
+{
+  programs.claude-code.skills = sharedSkills;
+  programs.codex.skills = sharedSkills;
+  programs.opencode.skills = sharedSkills;
+  programs.antigravity-cli.skills = sharedSkills;
+}

--- a/home-manager/modules/zsh.nix
+++ b/home-manager/modules/zsh.nix
@@ -31,11 +31,10 @@ in
       sessionVariables = {
         NIX_PATH = "$HOME/.nix-defexpr/channels:$NIX_PATH";
         FPATH = "$HOME/.zsh/completion:$FPATH";
-        PYTHON_CONFIGURE_OPTS = "--enable-framework";
-        UV_PYTHON_PREFERENCE = "system";
+        UV_PYTHON_PREFERENCE = "managed";
         CARGO_HOME = "$HOME/.cargo";
         RUSTUP_HOME = "$HOME/.rustup";
-        PATH = "$HOME/.local/bin:$HOME/.docker/bin:$HOME/.cargo/bin:/Library/TeX/texbin:/opt/homebrew/opt/gnu-getopt/bin:/opt/homebrew/opt/python@3.12/libexec/bin:$HOME/bin:$PATH";
+        PATH = "$HOME/.local/bin:$HOME/.docker/bin:$HOME/.cargo/bin:$HOME/bin:$PATH";
       }
       // lib.optionalAttrs bitwardenAgent.enable {
         DOTFILES_BITWARDEN_SSH_AGENT = "1";
@@ -76,6 +75,7 @@ in
           brew upgrade || return $?
 
           cd "$dotfile_dir" || return $?
+          nix flake update --flake "$dotfile_dir/home-manager/agent-extras" || return $?
           nix flake update || return $?
           _dotfiles_run_rebuild "$@" || return $?
 


### PR DESCRIPTION
## Summary

- **Skills**: `home-manager/agent-extras/` child flake pins 5 skill repos + 2 plugin marketplace repos; `modules/skills.nix` deploys shared skills to claude-code, codex, opencode, antigravity-cli
- **Plugins**: `modules/plugins.nix` auto-loads 14 claude-code plugins via `--plugin-dir` wrapper on every session — no manual `/install` on fresh machines
- **Package migration**: Moved python, uv, poetry, go, nodejs, bun, cmake, maven, pkg-config, kafka, infisical, kubevela from Homebrew → Nix for Linux parity
- **Cleanup**: Expanded global gitignore, removed macOS-hardcoded PATH entries, `update()` alias now updates child flake lock

## Test plan

- [ ] `darwin-rebuild switch` succeeds
- [ ] `which claude` → `/etc/profiles/per-user/.../bin/claude` (Nix store)
- [ ] `cat $(which claude)` shows 14 `--plugin-dir` flags
- [ ] Skills present in `~/.claude/skills/`
- [ ] `which go`, `which node`, `which uv` → Nix store paths
- [ ] `update` alias runs child flake update before root

🤖 Generated with [Claude Code](https://claude.com/claude-code)