### PR TITLE
fix(tmux): improve usage and system status clarity

### DIFF
--- a/home-manager/modules/claude-code/statusline.sh
+++ b/home-manager/modules/claude-code/statusline.sh
@@ -18,6 +18,7 @@ OUT_TOK=$(echo "$input" | jq -r '.context_window.current_usage.output_tokens // 
 CR_TOK=$(echo "$input" | jq -r '.context_window.current_usage.cache_read_input_tokens // 0')
 CW_TOK=$(echo "$input" | jq -r '.context_window.current_usage.cache_creation_input_tokens // 0')
 COST_RAW=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
+SESSION_ID=$(echo "$input" | jq -r '.session_id // empty')
 TOTAL_DURATION_MS=$(echo "$input" | jq -r '.cost.total_duration_ms // 0')
 API_TIME=$(echo "$input" | jq -r '.cost.total_api_duration_ms // 0')
 LINES_ADD=$(echo "$input" | jq -r '.cost.total_lines_added // 0')
@@ -79,6 +80,53 @@ CW_FMT=$(fmt_k "$CW_TOK")
 
 # Cost.
 COST_FMT=$(printf '$%.2f' "$COST_RAW")
+
+# Publish Claude Code's authoritative session cost for the tmux daily total.
+# Keep one local file per session so another Claude session cannot overwrite it.
+# Fixed path: the tmux server may have a different TMPDIR inherited from when
+# it started, so both processes must use an explicit shared location.
+CLAUDE_COST_DIR="/tmp/claude-cost-cache"
+mkdir -p "$CLAUDE_COST_DIR"
+CLAUDE_COST_DAY=$(date +%Y-%m-%d)
+CLAUDE_COST_CACHE="${CLAUDE_COST_DIR}/claude-${CLAUDE_COST_DAY}-${SESSION_ID:-unknown}.json"
+CLAUDE_COST_LOCK="${CLAUDE_COST_CACHE}.lock"
+CLAUDE_COST_TMP="${CLAUDE_COST_CACHE}.$$"
+if mkdir "$CLAUDE_COST_LOCK" 2>/dev/null; then
+  trap 'rmdir "$CLAUDE_COST_LOCK" 2>/dev/null || true' EXIT
+  PREVIOUS_TOTAL=$(jq -r '.session_total // 0' "$CLAUDE_COST_CACHE" 2>/dev/null || echo 0)
+  PREVIOUS_DAY_COST=$(jq -r '.cost // 0' "$CLAUDE_COST_CACHE" 2>/dev/null || echo 0)
+  if [ ! -f "$CLAUDE_COST_CACHE" ]; then
+    # If this session crossed midnight, use its last known cumulative total as
+    # today's baseline so yesterday's spend is not counted again.
+    PREVIOUS_TOTAL=$(find "$CLAUDE_COST_DIR" -maxdepth 1 -type f -name "claude-*-${SESSION_ID:-unknown}.json" -print 2>/dev/null \
+      | while IFS= read -r previous_file; do jq -r '.session_total // 0' "$previous_file" 2>/dev/null; done \
+      | sort -n | tail -1)
+    PREVIOUS_TOTAL=${PREVIOUS_TOTAL:-0}
+    PREVIOUS_DAY_COST=0
+  fi
+  if awk -v current="$COST_RAW" -v previous="$PREVIOUS_TOTAL" 'BEGIN { exit !(current >= previous) }'; then
+    EFFECTIVE_TOTAL="$COST_RAW"
+  else
+    EFFECTIVE_TOTAL="$PREVIOUS_TOTAL"
+  fi
+  DELTA=$(awk -v current="$EFFECTIVE_TOTAL" -v previous="$PREVIOUS_TOTAL" 'BEGIN { d = current - previous; if (d < 0) d = 0; printf "%.10f", d }')
+  COST_TO_PUBLISH=$(awk -v day="$PREVIOUS_DAY_COST" -v delta="$DELTA" 'BEGIN { printf "%.10f", day + delta }')
+  if jq -n \
+    --arg cost "$COST_TO_PUBLISH" \
+    --arg total "$EFFECTIVE_TOTAL" \
+    --arg session "$SESSION_ID" \
+    --arg cwd "$CWD" \
+    --arg day "$CLAUDE_COST_DAY" \
+    --arg updated "$(date +%s)" \
+    '{cost: ($cost | tonumber), session_total: ($total | tonumber), session_id: $session, cwd: $cwd, day: $day, updated_at: ($updated | tonumber)}' \
+    > "$CLAUDE_COST_TMP" 2>/dev/null; then
+    mv -f "$CLAUDE_COST_TMP" "$CLAUDE_COST_CACHE"
+  else
+    rm -f "$CLAUDE_COST_TMP"
+  fi
+  rmdir "$CLAUDE_COST_LOCK" 2>/dev/null || true
+  trap - EXIT
+fi
 
 # Timing.
 fmt_dur() {

--- a/home-manager/modules/zsh.nix
+++ b/home-manager/modules/zsh.nix
@@ -50,6 +50,15 @@ in
 
         source "${../scripts/zsh-integration.zsh}"
 
+        ${lib.optionalString profile.isWork ''
+          # Optional devcontainer-auto integration for the Work profile. The
+          # hook is installed outside this repository and should not make shell
+          # startup fail when absent.
+          if [ -r "$HOME/.config/devcontainer-auto/zsh-hook" ]; then
+            source "$HOME/.config/devcontainer-auto/zsh-hook"
+          fi
+        ''}
+
         _dotfiles_run_rebuild() {
           DOTFILE_DIR="${config.home.homeDirectory}/${userConfig.directories.dotfiles}" \
           CURRENT_CONFIG_HOST="${userConfig.hostname}" \

--- a/home-manager/scripts/tmux/status/codexbar.sh
+++ b/home-manager/scripts/tmux/status/codexbar.sh
@@ -8,40 +8,66 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CACHE_FILE="/tmp/codexbar_status.cache"
 CACHE_AGE_LIMIT=120 # 2 minutes
 
-calculate_claude_todays_cost() {
-  local today
-  today=$(date +%Y-%m-%d)
-  local cost_total="0.00"
+GREEN="#b8bb26"
+AMBER="#fabd2f"
+RED="#fb4934"
+MUTED="#928374"
+CLAUDE_COST_AMBER_THRESHOLD="${CLAUDE_COST_AMBER_THRESHOLD:-30}"
+CLAUDE_COST_RED_THRESHOLD="${CLAUDE_COST_RED_THRESHOLD:-60}"
 
-  if [ -d "$HOME/.claude/projects" ]; then
-    local matched_files
-    matched_files=$(find "$HOME/.claude/projects" -type f -name "*.jsonl" -mtime -1 2>/dev/null || true)
-    if [ -n "$matched_files" ]; then
-      cost_total=$(echo "$matched_files" | xargs grep -h "$today" 2>/dev/null | jq -s -r '
-        [ .[] | select(.message != null and .message.usage != null) |
-        ((.message.usage.input_tokens // 0) * 0.000003) + ((.message.usage.output_tokens // 0) * 0.000015) ] | add // 0
-      ' 2>/dev/null | awk '{printf "%.2f", $1}' 2>/dev/null || echo "0.00")
-    fi
-  fi
-
-  if [ -z "$cost_total" ] || [ "$cost_total" == "" ]; then
-    echo "0.00"
+quota_color() {
+  local remaining="${1:-}"
+  if ! [[ "$remaining" =~ ^[0-9]+$ ]]; then
+    echo "$MUTED"
+  elif (( remaining > 60 )); then
+    echo "$GREEN"
+  elif (( remaining >= 30 )); then
+    echo "$AMBER"
   else
-    echo "$cost_total"
+    echo "$RED"
   fi
+}
+
+cost_color() {
+  awk -v cost="${1:-0}" \
+    -v amber="$CLAUDE_COST_AMBER_THRESHOLD" \
+    -v red="$CLAUDE_COST_RED_THRESHOLD" \
+    -v green="$GREEN" -v amber_color="$AMBER" -v red_color="$RED" \
+    'BEGIN {
+      if (cost > red) print red_color
+      else if (cost >= amber) print amber_color
+      else print green
+    }'
+}
+
+read_claude_cost() {
+  local today raw_cost
+
+  today=$(date +%Y-%m-%d)
+  raw_cost=$(codexbar cost --provider claude --format json --refresh 2>/dev/null |
+    jq -r --arg today "$today" '
+      [.[] | .daily[]? | select(.date == $today) | .totalCost] |
+      add // 0
+    ' 2>/dev/null || echo 0)
+
+  awk -v cost="$raw_cost" 'BEGIN {
+    if (cost !~ /^[0-9]+(\.[0-9]+)?$/) cost = 0
+    printf "%.2f", cost + 0
+  }'
 }
 
 update_cache() {
   local openai_logo gemini_logo claude_logo
+  local cx_color agy_5h_color agy_week_color cc_color
   local codex_json codex_used codex_rem codex_str
   local agy_json gemini_5h_used gemini_w_used g5h_rem gw_rem agy_str
   local claude_cost claude_str full_status
   local codex_num g5h_num gw_num
 
-  # Keys styled in official brand colors, values in high-contrast Gruvbox cream (#ebdbb2)
-  openai_logo="#[fg=#10a37f]CX #[fg=#ebdbb2]"
-  gemini_logo="#[fg=#4285f4]AGY #[fg=#ebdbb2]"
-  claude_logo="#[fg=#d97757]CC #[fg=#ebdbb2]"
+  # Logos retain their provider colors; values indicate remaining quota/spend.
+  openai_logo="#[fg=#10a37f]CX "
+  gemini_logo="#[fg=#4285f4]AGY "
+  claude_logo="#[fg=#d97757]CC "
 
   # Fetch Codex quota
   codex_json=$(codexbar usage --provider codex --format json 2>/dev/null || echo "[]")
@@ -49,9 +75,10 @@ update_cache() {
   if [ -n "$codex_used" ] && [ "$codex_used" != "null" ]; then
     codex_num=$(echo "$codex_used" | awk '{print int($1)}')
     codex_rem=$(( 100 - codex_num ))
-    codex_str="${openai_logo}${codex_rem}%"
+    cx_color=$(quota_color "$codex_rem")
+    codex_str="${openai_logo}#[fg=${cx_color}]${codex_rem}%#[fg=#ebdbb2]"
   else
-    codex_str="${openai_logo}--%"
+    codex_str="${openai_logo}#[fg=${MUTED}]--%#[fg=#ebdbb2]"
   fi
 
   # Fetch Antigravity (Gemini) quota
@@ -64,14 +91,18 @@ update_cache() {
     gw_num=$(echo "$gemini_w_used" | awk '{print int($1)}')
     g5h_rem=$(( 100 - g5h_num ))
     gw_rem=$(( 100 - gw_num ))
-    agy_str="${gemini_logo}5h:${g5h_rem}% W:${gw_rem}%"
+    agy_5h_color=$(quota_color "$g5h_rem")
+    agy_week_color=$(quota_color "$gw_rem")
+    agy_str="${gemini_logo}#[fg=#ebdbb2]5h:#[fg=${agy_5h_color}]${g5h_rem}%#[fg=#ebdbb2] W:#[fg=${agy_week_color}]${gw_rem}%#[fg=#ebdbb2]"
   else
-    agy_str="${gemini_logo}--%"
+    agy_str="${gemini_logo}#[fg=${MUTED}]--%#[fg=#ebdbb2]"
   fi
 
-  # Calculate Claude today's cost
-  claude_cost=$(calculate_claude_todays_cost)
-  claude_str="${claude_logo}\$${claude_cost}"
+  # Use CodexBar's local-log scanner. It handles all sessions, model-specific
+  # rates, cache tokens, streaming deduplication, Pi sessions, and daily totals.
+  claude_cost=$(read_claude_cost)
+  cc_color=$(cost_color "$claude_cost")
+  claude_str="${claude_logo}#[fg=${cc_color}]\$${claude_cost}#[fg=#ebdbb2]"
 
   full_status="${codex_str} │ ${agy_str} │ ${claude_str}"
   echo "$full_status" > "${CACHE_FILE}.tmp" && mv "${CACHE_FILE}.tmp" "$CACHE_FILE"
@@ -96,6 +127,6 @@ tmux_status_collect_codexbar() {
   if [ -f "$CACHE_FILE" ]; then
     codexbar_status=$(cat "$CACHE_FILE")
   else
-    codexbar_status="#[fg=#10a37f]CX #[fg=#ebdbb2]--% │ #[fg=#4285f4]AGY #[fg=#ebdbb2]--% │ #[fg=#d97757]CC #[fg=#ebdbb2]\$0.00"
+    codexbar_status="#[fg=#10a37f]CX #[fg=${MUTED}]--%#[fg=#ebdbb2] │ #[fg=#4285f4]AGY #[fg=${MUTED}]--%#[fg=#ebdbb2] │ #[fg=#d97757]CC #[fg=${GREEN}]\$0.00#[fg=#ebdbb2]"
   fi
 }

--- a/home-manager/scripts/tmux/status/system.sh
+++ b/home-manager/scripts/tmux/status/system.sh
@@ -33,7 +33,12 @@ tmux_status_collect_system() {
 
   cpu_status=" $cpu"
 
-  mem="$(
+  mem_total_gb="$(
+    sysctl -n hw.memsize 2>/dev/null \
+      | awk '{ if ($1 > 0) printf "%.0f", $1 / 1024 / 1024 / 1024 }' \
+      || true
+  )"
+  mem_used_gb="$(
     vm_stat 2>/dev/null | awk '
       /page size of/ { pageSize = $8 }
       /Pages active/ { active = $3 }
@@ -47,39 +52,21 @@ tmux_status_collect_system() {
         gsub(/\./, "", wired);
         used = (active + inactive + speculative + wired) * pageSize / 1024 / 1024 / 1024;
         if (used > 0) {
-          printf "%.1fG", used;
+          printf "%.1f", used;
         }
       }
     ' \
     || true
   )"
-  [ -n "$mem" ] || mem="n/a"
-  mem_color="#ebdbb2"
-  mem_pressure="$(
-    vm_stat 2>/dev/null | awk '
-      /page size of/ { pageSize = $8 }
-      /Pages active/ { active = $3 }
-      /Pages inactive/ { inactive = $3 }
-      /Pages speculative/ { speculative = $3 }
-      /Pages wired down/ { wired = $4 }
-      /Pages free/ { free = $3 }
-      /Pages purgeable/ { purgeable = $3 }
-      /Pages compressed/ { compressed = $3 }
-      END {
-        gsub(/\./, "", active);
-        gsub(/\./, "", inactive);
-        gsub(/\./, "", speculative);
-        gsub(/\./, "", wired);
-        gsub(/\./, "", free);
-        gsub(/\./, "", purgeable);
-        gsub(/\./, "", compressed);
-        used = active + inactive + speculative + wired + compressed;
-        total = used + free + purgeable;
-        if (total > 0) printf "%.0f", (used / total) * 100;
-      }
-    ' \
-    || true
-  )"
+  if [ -n "$mem_used_gb" ] && [ -n "$mem_total_gb" ]; then
+    mem="${mem_used_gb}G/${mem_total_gb}G"
+  else
+    mem="n/a"
+  fi
+  mem_color="#b8bb26"
+  mem_pressure="$(awk -v used="$mem_used_gb" -v total="$mem_total_gb" \
+    'BEGIN { if (used > 0 && total > 0) printf "%.0f", (used / total) * 100 }' \
+    2>/dev/null || true)"
   if [ "$mem_pressure" -ge 90 ] 2>/dev/null; then
     mem_color="#fb4934"
   elif [ "$mem_pressure" -ge 75 ] 2>/dev/null; then


### PR DESCRIPTION
## Summary

The tmux statusline now reports Claude’s daily cost using CodexBar’s local-log scanner, so the displayed amount covers all sessions and model-specific cache pricing instead of relying on an incomplete custom estimate. System and AI status values now use consistent traffic-light colors, including RAM shown as used/max capacity and quota values colored by remaining capacity. The devcontainer shell hook is restricted to the Work profile and remains optional when the external hook is absent.

## Validation

- Passed Bash syntax checks for the status scripts.
- Passed `git diff --check`.
- Verified `codexbar cost --provider claude --format json` produces the daily total consumed by the statusline.
- Verified Home Manager deployment symlinks and corrected the stale deployed script during manual testing.
